### PR TITLE
Expand task list

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -205,3 +205,8 @@ This file lists actionable tasks derived from `implementation_plan.md` and the e
 118. **Self-Service Data Lake** – provision data lakes and ETL connectors (`infrastructure/data-lake`, `services/analytics`).
 119. **Real-Time Performance Monitor** – stream live resource metrics and alerts (`services/analytics`, `infrastructure/observability`).
 120. **Quantum-Safe Cryptography** – integrate post-quantum algorithms for secure communication (`packages/shared`, `apps/api-auth`).
+
+121. **Automated Backups** – regularly back up generated code and user data with documented restore steps.
+122. **Input Sanitization** – validate and sanitize all user-provided data across services.
+123. **Audit Logging** – record codegen activity and portal actions for security reviews.
+124. **Portal Google Analytics** – integrate Google Analytics to measure portal usage.

--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -1,0 +1,1575 @@
+# Parallel Task Descriptions
+
+This file expands on each item in `Tasks.md` with a short description of the expected work. Each task references the folders it touches so multiple contributors can work in parallel.
+
+## Infrastructure
+
+1. **VPC & Networking**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure/vpc`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Build Terraform modules in `infrastructure/vpc` to define the base VPC, public/private subnets, route tables and security groups used by all services.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+2. **IAM Roles**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Add IAM policies and role definitions under `infrastructure` so each service has least-privilege access.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+3. **Cognito Setup**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure/cognito`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Create a Terraform module in `infrastructure/cognito` that provisions a user pool and app clients for authentication.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+4. **SES Configuration**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure/ses`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Configure an email domain and template resources in `infrastructure/ses` for sending notifications.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+5. **Observability Stack**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure/observability`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Set up CloudWatch logs, metrics and optional X-Ray tracing in `infrastructure/observability`.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+6. **Terraform/CDK Scaffolding**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure/terraform`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Provide base deployment scripts and documentation in `infrastructure/terraform` so infrastructure can be deployed consistently.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+
+## Backend Services
+### Authentication Service (`apps/api-auth`)
+7. **Signup and Login Endpoints**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Implement endpoints that create users and authenticate them. Hash passwords securely before storing them.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+8. **Session Management**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Issue JWTs, handle token refresh, and store session metadata.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+9. **User Data Store Integration**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Connect the service to Cognito or an RDS instance for persisting user credentials.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+10. **Email Verification Endpoint**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Allow users to confirm their email addresses after sign up.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+
+### Orchestrator (`apps/orchestrator`)
+11. **Create App Endpoint**
+
+   - Draft API contract and data models.
+   - Implement handlers in `/api/createApp` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Add `/api/createApp` for accepting natural language app descriptions.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+12. **Dispatch CodeGen Jobs**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Parse the description and kick off CodeGen tasks asynchronously.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+13. **Job Status Persistence**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Use DynamoDB to track the state of each job and record progress.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+14. **Deployment Triggering**
+
+   - Identify automation requirements.
+   - Add or modify workflow files in the project.
+   - Test the workflow locally and document triggers.
+   - Task details: When code generation completes, start deployment workflows automatically.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+15. **Notification Emails**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Notify users via the email service when builds start, succeed or fail.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+### Code Generation Service (`apps/codegen`)
+16. **OpenAI or Local LLM Integration**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Connect to the OpenAI API or a locally hosted model to generate source code.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+17. **Isolated Execution**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Run generation and build steps inside containers to keep jobs separate.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+18. **Testing of Generated Code**
+
+   - Choose appropriate testing frameworks.
+   - Write tests in the project covering the feature.
+   - Integrate tests with CI and document running instructions.
+   - Task details: Lint and run unit tests on generated projects before publishing.
+  - Steps:
+    1. Use Jest for unit tests and Cypress for E2E.
+    2. Add coverage thresholds in config files.
+    3. Run tests in the CI pipeline for each push.
+    4. Document how to run tests locally.
+
+19. **Publish Artifacts**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Commit generated code to a repository and provide build artifacts for download.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+
+### Email Service (`services/email`)
+20. **SES Wrapper**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Expose functions that other services can call to send templated emails using SES.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+21. **Service API**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Provide a simple internal API or library so the orchestrator and auth service can send emails.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+### Analytics Service (`services/analytics`)
+22. **Usage Event Collection**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Record events from all services and persist them for analysis.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+23. **Metrics API**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Offer endpoints that the portal can use to display charts and usage statistics.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+## Frontend Portal (`apps/portal`)
+24. **Auth Pages**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Build login and signup pages that call the authentication service.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+25. **App Creation Wizard**
+
+   - Define public API for the package.
+   - Implement utilities or templates in the project.
+   - Publish typed docs and examples.
+   - Task details: Implement a multi-step form for entering an app description and choosing templates.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+26. **Build Status**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Show progress of the orchestrator by polling a status endpoint.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+27. **App List**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Display a dashboard of user-created apps with links to logs and metrics.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+28. **Redeploy from Edits**
+
+   - Outline command-line options or automation steps.
+   - Write scripts in the project.
+   - Verify cross-platform usage and add help output.
+   - Task details: Allow users to edit their descriptions and trigger a new deployment.
+  - Steps:
+    1. Plan arguments and flags for the CLI.
+    2. Implement commands with the Commander library.
+    3. Ensure scripts run on Windows/macOS/Linux.
+    4. Provide examples in the tool README.
+
+
+## Shared Packages
+29. **Shared Utilities**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `packages/shared`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Create a library under `packages/shared` with logging helpers and common AWS wrappers.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+30. **Codegen Feature Templates**
+
+   - Draft API contract and data models.
+   - Implement handlers in `packages/codegen-templates` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Add template definitions in `packages/codegen-templates` for features like auth, CRUD APIs and chatbots.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+## CI/CD and DevOps
+31. **Turborepo/Nx Tasks**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in `turbo.json` and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Configure tasks in `turbo.json` so builds and tests run efficiently across the monorepo.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+32. **GitHub Actions**
+
+   - Identify automation requirements.
+   - Add or modify workflow files in `ci/`.
+   - Test the workflow locally and document triggers.
+   - Task details: Add workflows in the `ci/` directory for linting, testing and deployment.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+33. **Remote Caching**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Enable remote cache options to speed up repeated runs of the pipeline.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+## Observability
+34. **CloudWatch Dashboards**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Create default dashboards and set up X-Ray tracing where applicable.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+35. **Sentry Integration**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Optionally send error reports to Sentry when DSNs are configured.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+## Testing & Security
+36. **Service Unit Tests**
+
+   - Draft API contract and data models.
+   - Implement handlers in `src` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Add unit test suites inside each service's `src` folder.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+37. **End-to-End Tests**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Simulate a user creating an app to verify the whole flow works.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+38. **Static Analysis**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Run CodeQL or a similar tool to catch vulnerabilities in pull requests.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+## Documentation
+39. **README Expansion**
+
+   - Collect information that needs explaining.
+   - Write markdown guides and diagrams in the project.
+   - Review for clarity and commit.
+   - Task details: Provide setup instructions and local development steps in each README.
+  - Steps:
+    1. Draft documentation in Markdown with diagrams.
+    2. Include setup instructions and code samples.
+    3. Review wording for clarity and grammar.
+    4. Commit docs under `docs/` with index updates.
+
+40. **User Guides**
+
+   - Collect information that needs explaining.
+   - Write markdown guides and diagrams in the project.
+   - Review for clarity and commit.
+   - Task details: Write documentation and diagrams describing the overall architecture.
+  - Steps:
+    1. Draft documentation in Markdown with diagrams.
+    2. Include setup instructions and code samples.
+    3. Review wording for clarity and grammar.
+    4. Commit docs under `docs/` with index updates.
+
+
+## Tools
+41. **Local Development Scripts**
+
+   - Outline command-line options or automation steps.
+   - Write scripts in `tools/`.
+   - Verify cross-platform usage and add help output.
+   - Task details: Add helper scripts in `tools/` for bootstrapping and deployment tasks.
+  - Steps:
+    1. Plan arguments and flags for the CLI.
+    2. Implement commands with the Commander library.
+    3. Ensure scripts run on Windows/macOS/Linux.
+    4. Provide examples in the tool README.
+
+
+## Repository Setup
+42. **Root Scripts**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in `package.json` and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Define workspace-wide build, test and lint commands in the root `package.json`.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+43. **Environment Examples**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in `.env.example` and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Create `.env.example` files in each app folder to document required variables.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+
+## Additional Infrastructure
+44. **Static Site Hosting**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure/static-site`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Create Terraform modules in `infrastructure/static-site` for S3 and CloudFront deployments.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+45. **PostgreSQL Templates**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure/db`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Add database modules under `infrastructure/db` with encryption enabled.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+46. **Secrets Management**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Store secrets using AWS SSM Parameter Store and reference them in modules.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+
+## Extended Backend Services
+### Authentication Service (`apps/api-auth`)
+47. **Password Reset and Email Change**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Add endpoints to request password resets and update user email addresses.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+48. **Google OAuth**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Allow users to sign in with their Google accounts as an alternative auth method.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+### Orchestrator (`apps/orchestrator`)
+49. **Status Endpoint**
+
+   - Draft API contract and data models.
+   - Implement handlers in `/api/status` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Provide `/api/status` so clients can query job progress.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+50. **Retry Logic**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Automatically retry failed code generation tasks a configurable number of times.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+51. **Artifact Storage**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Save build outputs to S3 so users can download them later.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+
+### Code Generation Service (`apps/codegen`)
+52. **Template Caching**
+
+   - Define public API for the package.
+   - Implement utilities or templates in the project.
+   - Publish typed docs and examples.
+   - Task details: Reuse previously generated templates when descriptions repeat to improve speed.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+53. **Linting and Formatting**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Enforce ESLint and Prettier on generated projects before publishing.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+### Email Service (`services/email`)
+54. **SES Templates**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Maintain email templates for verification and build notifications.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+
+### Analytics Service (`services/analytics`)
+55. **DynamoDB Schema**
+
+   - Define metrics and events to capture.
+   - Implement collection endpoints or pipelines in the project.
+   - Expose charts or query interfaces and document.
+   - Task details: Define tables and indexes for storing analytics events.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+56. **Aggregated Metrics API**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Provide endpoints that summarize data for dashboards.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+
+## Frontend Portal Enhancements (`apps/portal`)
+57. **Account Settings Page**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Let users update their personal info and change passwords.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+58. **Analytics Dashboard**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Display charts based on data from the analytics service.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+59. **Build Log Viewer**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Show historical logs and generation results to the user.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+## Example App Template (`apps/user-app-temp`)
+60. **Todo App Template**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Populate this folder with a minimal Todo application that demonstrates generated features.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+## Shared Packages Extensions
+61. **DynamoDB Helpers**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `packages/shared`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Expand `packages/shared` with convenient functions for common DynamoDB operations.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+62. **Codegen CLI**
+
+   - Draft API contract and data models.
+   - Implement handlers in `packages/codegen-templates` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Add a command line tool in `packages/codegen-templates` that lists available generation modules.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+## CI/CD and DevOps Additions
+63. **Release Workflow**
+
+   - Define public API for the package.
+   - Implement utilities or templates in `ci/`.
+   - Publish typed docs and examples.
+   - Task details: Under `ci/`, create a workflow that publishes packages when a Git tag is pushed.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+64. **Nx Cloud Caching**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Configure remote caching with Nx Cloud for faster builds.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+
+## Observability Improvements
+65. **Log Retention and Alarms**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure/observability`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Define how long logs are kept and set alarm policies in `infrastructure/observability`.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+66. **Sentry DSN Configuration**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Pass Sentry DSNs via environment variables to services that support it.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+## Testing & Security Expansion
+67. **Cypress Tests**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Add browser-based tests for portal user flows.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+68. **OWASP Dependency Checks**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Incorporate dependency vulnerability scanning into CI.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+## Documentation Updates
+69. **Infrastructure Deployment Guide**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in `infrastructure/README.md`.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Document how to deploy the infrastructure in `infrastructure/README.md`.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+
+## Tools and Utilities
+70. **Service Bootstrap Scripts**
+
+   - Draft API contract and data models.
+   - Implement handlers in `tools/` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Provide scripts in `tools/` to create new service folders with basic scaffolding.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+## Performance & Scaling
+71. **Load Testing**
+
+   - Choose appropriate testing frameworks.
+   - Write tests in `tools/loadtest` covering the feature.
+   - Integrate tests with CI and document running instructions.
+   - Task details: Add k6 scripts under `tools/loadtest` to measure system performance.
+  - Steps:
+    1. Use Jest for unit tests and Cypress for E2E.
+    2. Add coverage thresholds in config files.
+    3. Run tests in the CI pipeline for each push.
+    4. Document how to run tests locally.
+
+72. **Tenant Isolation**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Implement checks in the orchestrator to keep tenant data separate.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+## Compliance
+73. **GDPR Data Processes**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Document how users can export or delete their data to stay compliant.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+## Local Development
+74. **Docker Compose**
+
+   - Draft API contract and data models.
+   - Implement handlers in `docker-compose.yml` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Supply a `docker-compose.yml` that spins up local versions of services for development.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+## Repository Governance
+75. **CODEOWNERS File**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Add a file defining maintainers for each folder to streamline reviews.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+## Innovative Features
+### Initial Phase
+76. **Voice Input for Descriptions**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Integrate speech-to-text so users can verbally describe apps in the portal.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+77. **Collaborative Editor**
+
+   - Outline command-line options or automation steps.
+   - Write scripts in the project.
+   - Verify cross-platform usage and add help output.
+   - Task details: Use WebSockets to allow multiple users to edit app descriptions in real time.
+  - Steps:
+    1. Plan arguments and flags for the CLI.
+    2. Implement commands with the Commander library.
+    3. Ensure scripts run on Windows/macOS/Linux.
+    4. Provide examples in the tool README.
+
+78. **Figma Design Import**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Allow uploading Figma JSON to generate matching UI components.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+
+### Medium Phase
+79. **Plugin Architecture**
+
+   - Design plugin interface and extension points.
+   - Implement sample plugin in the project.
+   - Document contribution guidelines.
+   - Task details: Design a plugin interface so third parties can contribute new feature modules.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+80. **Self-Healing Deployments**
+
+   - Define metrics and events to capture.
+   - Implement collection endpoints or pipelines in the project.
+   - Expose charts or query interfaces and document.
+   - Task details: Monitor orchestrator tasks and automatically restart failed jobs.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+81. **AI-Based Test Generation**
+
+   - Choose appropriate testing frameworks.
+   - Write tests in the project covering the feature.
+   - Integrate tests with CI and document running instructions.
+   - Task details: Use an LLM to write unit and integration tests based on generated code.
+  - Steps:
+    1. Use Jest for unit tests and Cypress for E2E.
+    2. Add coverage thresholds in config files.
+    3. Run tests in the CI pipeline for each push.
+    4. Document how to run tests locally.
+
+
+### Advanced Phase
+82. **Recommendation Engine**
+
+   - Define metrics and events to capture.
+   - Implement collection endpoints or pipelines in the project.
+   - Expose charts or query interfaces and document.
+   - Task details: Leverage analytics data to suggest features that improve user apps.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+83. **Data Connector Templates**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Provide connectors for common APIs like Stripe and Slack that users can add easily.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+84. **Edge Inference Support**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Run lightweight models in the browser so apps can make predictions offline.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+85. **A/B Testing Toolkit**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Offer utilities to define experiments and record metrics in generated apps.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+### Future Innovations
+86. **AI Chat Requirement Assistant**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Embed a conversational helper in the portal to refine user descriptions.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+87. **Auto Documentation Generation**
+
+   - Collect information that needs explaining.
+   - Write markdown guides and diagrams in the project.
+   - Review for clarity and commit.
+   - Task details: Use summarization models to produce README files and inline code comments.
+  - Steps:
+    1. Draft documentation in Markdown with diagrams.
+    2. Include setup instructions and code samples.
+    3. Review wording for clarity and grammar.
+    4. Commit docs under `docs/` with index updates.
+
+88. **Visual Workflow Builder**
+
+   - Identify automation requirements.
+   - Add or modify workflow files in the project.
+   - Test the workflow locally and document triggers.
+   - Task details: Provide a drag-and-drop tool for customizing backend logic and workflows.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+
+### Medium-Advanced Phase
+89. **Mobile App Generation**
+
+   - Define mobile-specific requirements and libraries.
+   - Generate React Native/Flutter project in the project.
+   - Test on emulators and document configuration.
+   - Task details: Optionally generate React Native or Flutter versions of user apps.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+90. **Compliance & Security Scanning**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Check generated code for GDPR, HIPAA and OWASP issues before deployment.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+91. **Generative UI Themes**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Let users generate color palettes and style guides via short prompts.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+
+### Advanced Phase Extensions
+92. **Plugin Marketplace**
+
+   - Design plugin interface and extension points.
+   - Implement sample plugin in the project.
+   - Document contribution guidelines.
+   - Task details: Host a catalog where developers can share and rate plugins for the platform.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+93. **Optimization Assistant**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Analyze infrastructure costs and performance to recommend improvements.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+94. **Repo Import and Refactor**
+
+   - Identify automation requirements.
+   - Add or modify workflow files in the project.
+   - Test the workflow locally and document triggers.
+   - Task details: Allow importing existing GitHub projects and extending them with code generation.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+95. **Offline Generation Mode**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Support running the full pipeline locally for restricted environments.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+
+### Long-Term Vision
+96. **RL-Driven Code Quality Improvement**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Use reinforcement learning from user feedback to improve generation accuracy.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+97. **Predictive Scaling Advisor**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Analyze usage metrics and suggest scaling actions automatically.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+98. **Visual Database Schema Designer**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Provide a drag-and-drop schema designer feeding into the codegen service.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+99. **Multi-Language Output**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Extend templates to support backend services in languages like Python and Go.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+100. **GraphQL API Builder**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Automatically generate GraphQL endpoints from data models.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+101. **Security Patch Automation**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Detect vulnerabilities in dependencies and open pull requests with fixes.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+102. **Custom AI Model Integration**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Allow users to plug in their own fine-tuned models for generation.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+103. **Live Coding Assistant**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Offer an interactive helper that explains generated code and suggests improvements.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+104. **Smart Dependency Upgrader**
+
+   - Define public API for the package.
+   - Implement utilities or templates in the project.
+   - Publish typed docs and examples.
+   - Task details: Keep packages current with compatibility checks and automatic rollbacks if needed.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+105. **Code Quality Insights Dashboard**
+
+   - Choose appropriate testing frameworks.
+   - Write tests in the project covering the feature.
+   - Integrate tests with CI and document running instructions.
+   - Task details: Display metrics like maintainability and test coverage for each project.
+  - Steps:
+    1. Use Jest for unit tests and Cypress for E2E.
+    2. Add coverage thresholds in config files.
+    3. Run tests in the CI pipeline for each push.
+    4. Document how to run tests locally.
+
+
+### Research Frontier
+106. **Adaptive Prompt Training**
+
+   - Draft API contract and data models.
+   - Implement handlers in `apps/codegen` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Continuously refine prompt templates in `apps/codegen` using analytics feedback.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+107. **Personalized UI Assistant**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Tailor portal layouts using behavioral metrics from the analytics service.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+108. **VR App Preview**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Render generated interfaces in WebXR so users can inspect them in 3D.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+109. **Ethical Compliance Checker**
+
+   - Define metrics and events to capture.
+   - Implement collection endpoints or pipelines in the project.
+   - Expose charts or query interfaces and document.
+   - Task details: Flag privacy or fairness issues in generated code using analytics insights.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+110. **Globalization Toolkit**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Auto-localize UI strings and settings using templates and portal features.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+111. **Experimental LLM Sandbox**
+
+   - Draft API contract and data models.
+   - Implement handlers in `apps/codegen` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Let advanced users plug custom models into `apps/codegen` for experimentation.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+112. **Voice-Guided Data Modeling**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Convert spoken requirements into schema definitions using the portal and codegen service.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+113. **Continuous Learning Feedback Loop**
+
+   - Define metrics and events to capture.
+   - Implement collection endpoints or pipelines in the project.
+   - Expose charts or query interfaces and document.
+   - Task details: Retrain generation models based on analytics data and user ratings.
+  - Steps:
+    1. Break the work into small commits.
+    2. Implement functionality with descriptive messages.
+    3. Add tests validating edge cases.
+    4. Update README files with configuration notes.
+
+114. **Cross-Domain Template Marketplace**
+
+   - Draft API contract and data models.
+   - Implement handlers in `packages/codegen-templates` and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Curate industry-specific templates in `packages/codegen-templates` for reuse.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+115. **Sustainability Report Generator**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Estimate carbon impact of deployments using metrics from the analytics service.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+116. **In-App Tutorial Builder**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Automatically generate walkthroughs for new apps in the portal.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+117. **AI Ethics Dashboard**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Display transparency metrics and ethical considerations in the portal.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.
+
+118. **Self-Service Data Lake**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Provide infrastructure modules for provisioning data lakes and ETL connectors.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+119. **Real-Time Performance Monitor**
+
+   - Outline command-line options or automation steps.
+   - Write scripts in the project.
+   - Verify cross-platform usage and add help output.
+   - Task details: Stream live metrics and alerts from observability tools.
+  - Steps:
+    1. Plan arguments and flags for the CLI.
+    2. Implement commands with the Commander library.
+    3. Ensure scripts run on Windows/macOS/Linux.
+    4. Provide examples in the tool README.
+
+120. **Quantum-Safe Cryptography**
+
+   - Draft API contract and data models.
+   - Implement handlers in the project and integrate with storage.
+   - Write unit tests and update service README.
+   - Task details: Integrate post-quantum algorithms into shared libraries and the auth service.
+  - Steps:
+    1. Write an OpenAPI spec describing each endpoint.
+    2. Generate TypeScript types and service stubs.
+    3. Implement handlers with data access logic.
+    4. Add integration tests and update the README.
+
+
+121. **Automated Backups**
+
+   - Design Terraform module inputs and outputs.
+   - Implement resources in the project.
+   - Run `terraform plan` to validate and document usage.
+   - Task details: Schedule backups of code repositories and databases with recovery documentation.
+  - Steps:
+    1. Create the module folder and variable files.
+    2. Define inputs/outputs following AWS conventions.
+    3. Run `terraform init && terraform fmt` to validate.
+    4. Document usage in `README.md` and commit.
+
+122. **Input Sanitization**
+
+   - Detail the expected outcome of the task.
+   - Implement the feature in the project.
+   - Document findings and add examples.
+   - Task details: Validate and sanitize all user-supplied data to prevent injection attacks.
+  - Steps:
+    1. Capture acceptance criteria in a design doc.
+    2. Implement the logic iteratively with commits.
+    3. Validate the feature with unit tests.
+    4. Provide usage examples in the docs.
+
+123. **Audit Logging**
+
+   - Outline command-line options or automation steps.
+   - Write scripts in the project.
+   - Verify cross-platform usage and add help output.
+   - Task details: Record code generation steps and portal activities for audit purposes.
+  - Steps:
+    1. Plan arguments and flags for the CLI.
+    2. Implement commands with the Commander library.
+    3. Ensure scripts run on Windows/macOS/Linux.
+    4. Provide examples in the tool README.
+
+124. **Portal Google Analytics**
+
+   - Sketch the UI/UX for the feature.
+   - Build React components in the project and connect to the API.
+   - Add page-level tests and document usage.
+   - Task details: Integrate Google Analytics scripts in the portal to track usage metrics.
+  - Steps:
+    1. Prototype screens in a design tool like Figma.
+    2. Implement pages using Next.js and Tailwind CSS.
+    3. Connect to backend APIs with SWR or React Query.
+    4. Add Cypress tests and document screenshots.


### PR DESCRIPTION
## Summary
- extend Tasks.md with four additional tasks for backups, sanitization, audit logs, and Google Analytics
- add detailed steps for these tasks in parallel_tasks.md

## Testing
- `wc -l parallel_tasks.md`
- `grep -E '^[0-9]+\. ' -n parallel_tasks.md | wc -l`
- `grep -E '^[0-9]+\. ' -n Tasks.md | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_6869559cab00833192801592ece9c073