### PR TITLE
Add infra modules and retry helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@ Describe your idea. We generate the code, deploy it, and scale it—automaticall
 
 This repository uses a monorepo structure as outlined in `implementation_plan.md`.
 The folders are currently scaffolds that will contain the platform services.
+
+## New Modules
+
+- `infrastructure/vpc` - Terraform VPC module.
+- `infrastructure/artifacts` - S3 artifact storage module.
+- `packages/retry` - reusable retry utility for async tasks.

--- a/infrastructure/artifacts/README.md
+++ b/infrastructure/artifacts/README.md
@@ -1,0 +1,15 @@
+# Artifact Storage Module
+
+This module provisions an S3 bucket for storing build artifacts. Versioning is
+enabled so previous outputs can be retained.
+
+## Usage
+
+```hcl
+module "artifacts" {
+  source      = "./infrastructure/artifacts"
+  bucket_name = "my-artifacts-bucket"
+}
+```
+
+Initialize with `terraform init` and review with `terraform plan`.

--- a/infrastructure/artifacts/main.tf
+++ b/infrastructure/artifacts/main.tf
@@ -1,0 +1,11 @@
+resource "aws_s3_bucket" "artifacts" {
+  bucket = var.bucket_name
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.artifacts.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/infrastructure/artifacts/outputs.tf
+++ b/infrastructure/artifacts/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket_name" {
+  description = "Artifact bucket name"
+  value       = aws_s3_bucket.artifacts.id
+}

--- a/infrastructure/artifacts/variables.tf
+++ b/infrastructure/artifacts/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket for artifact storage"
+  type        = string
+}

--- a/infrastructure/vpc/README.md
+++ b/infrastructure/vpc/README.md
@@ -1,3 +1,24 @@
-# vpc
+# VPC Module
 
-Infrastructure templates for vpc.
+This Terraform module provisions the base networking layer used by the platform.
+It creates a VPC along with public and private subnets.
+
+## Usage
+
+```hcl
+module "vpc" {
+  source             = "./infrastructure/vpc"
+  vpc_cidr           = "10.0.0.0/16"
+  vpc_name           = "demo"
+  public_subnets     = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnets    = ["10.0.101.0/24", "10.0.102.0/24"]
+  availability_zones = ["us-east-1a", "us-east-1b"]
+}
+```
+
+Initialize and format the module with:
+
+```bash
+terraform init
+terraform fmt
+```

--- a/infrastructure/vpc/main.tf
+++ b/infrastructure/vpc/main.tf
@@ -1,0 +1,21 @@
+resource "aws_vpc" "this" {
+  cidr_block = var.vpc_cidr
+  tags = {
+    Name = var.vpc_name
+  }
+}
+
+resource "aws_subnet" "public" {
+  count = length(var.public_subnets)
+  vpc_id     = aws_vpc.this.id
+  cidr_block = var.public_subnets[count.index]
+  map_public_ip_on_launch = true
+  availability_zone = element(var.availability_zones, count.index)
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.private_subnets)
+  vpc_id     = aws_vpc.this.id
+  cidr_block = var.private_subnets[count.index]
+  availability_zone = element(var.availability_zones, count.index)
+}

--- a/infrastructure/vpc/outputs.tf
+++ b/infrastructure/vpc/outputs.tf
@@ -1,0 +1,4 @@
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.this.id
+}

--- a/infrastructure/vpc/variables.tf
+++ b/infrastructure/vpc/variables.tf
@@ -1,0 +1,26 @@
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "vpc_name" {
+  description = "Name tag for the VPC"
+  type        = string
+  default     = "iac-main"
+}
+
+variable "public_subnets" {
+  description = "List of public subnet CIDRs"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "List of private subnet CIDRs"
+  type        = list(string)
+}
+
+variable "availability_zones" {
+  description = "List of AZs"
+  type        = list(string)
+}

--- a/packages/retry/README.md
+++ b/packages/retry/README.md
@@ -1,0 +1,3 @@
+# retry package
+
+Utility to automatically retry failed asynchronous tasks a configurable number of times.

--- a/packages/retry/package.json
+++ b/packages/retry/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "retry",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/packages/retry/src/README.md
+++ b/packages/retry/src/README.md
@@ -1,0 +1,9 @@
+# Retry Utility
+
+This package provides a simple async `retry` function used to repeat failed tasks.
+
+```
+import { retry } from 'retry';
+
+await retry(() => doSomething(), 5, 1000);
+```

--- a/packages/retry/src/index.ts
+++ b/packages/retry/src/index.ts
@@ -1,0 +1,14 @@
+export async function retry<T>(fn: () => Promise<T>, attempts = 3, delayMs = 500): Promise<T> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (i < attempts - 1) {
+        await new Promise(res => setTimeout(res, delayMs));
+      }
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Summary
- scaffold Terraform module for VPC networking
- add artifact storage S3 module
- implement generic async retry utility

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869eaee55408331a066c4b56cde3fd3