### PR TITLE
Implement core infra modules and basic services

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,14 @@ The folders are currently scaffolds that will contain the platform services.
 
 - `infrastructure/vpc` - Terraform VPC module.
 - `infrastructure/artifacts` - S3 artifact storage module.
-- `packages/retry` - reusable retry utility for async tasks.
+- `infrastructure/iam` - IAM role definitions.
+- `infrastructure/cognito` - User pool provisioning.
+- `infrastructure/ses` - Email domain and templates.
+- `infrastructure/observability` - CloudWatch and X-Ray setup.
+- `infrastructure/terraform` - Example stack wiring modules together.
+- `packages/retry` - Reusable retry utility for async tasks.
+- `packages/shared` - AWS helpers including DynamoDB utilities.
+- `packages/codegen-templates` - Template library with a CLI.
+- `services/email` - SES wrapper for sending templated emails.
+- `services/analytics` - Basic event collection API.
+

--- a/infrastructure/cognito/README.md
+++ b/infrastructure/cognito/README.md
@@ -1,3 +1,14 @@
-# cognito
+# Cognito Module
 
-Infrastructure templates for cognito.
+This module provisions a user pool and app client used for authentication.
+
+## Usage
+```hcl
+module "cognito" {
+  source          = "./infrastructure/cognito"
+  user_pool_name  = "demo-users"
+  app_client_name = "demo-client"
+}
+```
+
+Run `terraform init` then `terraform plan` to review resources.

--- a/infrastructure/cognito/main.tf
+++ b/infrastructure/cognito/main.tf
@@ -1,0 +1,9 @@
+resource "aws_cognito_user_pool" "this" {
+  name = var.user_pool_name
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  name         = var.app_client_name
+  user_pool_id = aws_cognito_user_pool.this.id
+  generate_secret = false
+}

--- a/infrastructure/cognito/outputs.tf
+++ b/infrastructure/cognito/outputs.tf
@@ -1,0 +1,9 @@
+output "user_pool_id" {
+  value       = aws_cognito_user_pool.this.id
+  description = "ID of the user pool"
+}
+
+output "client_id" {
+  value       = aws_cognito_user_pool_client.client.id
+  description = "ID of the app client"
+}

--- a/infrastructure/cognito/variables.tf
+++ b/infrastructure/cognito/variables.tf
@@ -1,0 +1,9 @@
+variable "user_pool_name" {
+  description = "Name of the Cognito user pool"
+  type        = string
+}
+
+variable "app_client_name" {
+  description = "Name of the user pool client"
+  type        = string
+}

--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -1,0 +1,15 @@
+# IAM Roles Module
+
+This Terraform module creates IAM roles with attached policies so services can operate with least privilege.
+
+## Usage
+```hcl
+module "iam" {
+  source            = "./infrastructure/iam"
+  role_name         = "demo-role"
+  assume_role_service = "lambda.amazonaws.com"
+  policy_json       = file("./policy.json")
+}
+```
+
+Run `terraform init` and `terraform fmt` in this directory before applying.

--- a/infrastructure/iam/main.tf
+++ b/infrastructure/iam/main.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_role" "this" {
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = [var.assume_role_service]
+    }
+  }
+}
+
+resource "aws_iam_policy" "custom" {
+  name   = "${var.role_name}-policy"
+  policy = var.policy_json
+}
+
+resource "aws_iam_role_policy_attachment" "attach" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.custom.arn
+}

--- a/infrastructure/iam/outputs.tf
+++ b/infrastructure/iam/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  description = "ARN of the created role"
+  value       = aws_iam_role.this.arn
+}

--- a/infrastructure/iam/variables.tf
+++ b/infrastructure/iam/variables.tf
@@ -1,0 +1,14 @@
+variable "role_name" {
+  description = "Name of the IAM role"
+  type        = string
+}
+
+variable "assume_role_service" {
+  description = "Service that can assume this role"
+  type        = string
+}
+
+variable "policy_json" {
+  description = "JSON policy document"
+  type        = string
+}

--- a/infrastructure/observability/README.md
+++ b/infrastructure/observability/README.md
@@ -1,3 +1,13 @@
-# observability
+# Observability Module
 
-Infrastructure templates for observability.
+Sets up CloudWatch Logs and X-Ray groups for application monitoring.
+
+## Usage
+```hcl
+module "observability" {
+  source         = "./infrastructure/observability"
+  log_group_name = "app-logs"
+}
+```
+
+Run `terraform init && terraform fmt` before apply.

--- a/infrastructure/observability/main.tf
+++ b/infrastructure/observability/main.tf
@@ -1,0 +1,9 @@
+resource "aws_cloudwatch_log_group" "app" {
+  name = var.log_group_name
+  retention_in_days = 14
+}
+
+resource "aws_xray_group" "default" {
+  filter_expression = "service('all')"
+  group_name        = "${var.log_group_name}-xray"
+}

--- a/infrastructure/observability/outputs.tf
+++ b/infrastructure/observability/outputs.tf
@@ -1,0 +1,4 @@
+output "log_group_arn" {
+  value       = aws_cloudwatch_log_group.app.arn
+  description = "ARN of the log group"
+}

--- a/infrastructure/observability/variables.tf
+++ b/infrastructure/observability/variables.tf
@@ -1,0 +1,4 @@
+variable "log_group_name" {
+  description = "Name for the CloudWatch log group"
+  type        = string
+}

--- a/infrastructure/ses/README.md
+++ b/infrastructure/ses/README.md
@@ -1,3 +1,15 @@
-# ses
+# SES Module
 
-Infrastructure templates for ses.
+Configures Amazon SES for sending notification emails including a default template.
+
+## Usage
+```hcl
+module "ses" {
+  source          = "./infrastructure/ses"
+  domain          = "example.com"
+  template_name   = "build"
+  template_subject = "Build Notification"
+}
+```
+
+Initialize with `terraform init` and format with `terraform fmt`.

--- a/infrastructure/ses/main.tf
+++ b/infrastructure/ses/main.tf
@@ -1,0 +1,14 @@
+resource "aws_ses_domain_identity" "domain" {
+  domain = var.domain
+}
+
+resource "aws_ses_email_identity" "notifications" {
+  email = "no-reply@${var.domain}"
+}
+
+resource "aws_ses_template" "default" {
+  name       = var.template_name
+  html       = var.template_html
+  subject    = var.template_subject
+  text       = var.template_text
+}

--- a/infrastructure/ses/outputs.tf
+++ b/infrastructure/ses/outputs.tf
@@ -1,0 +1,4 @@
+output "identity_arn" {
+  value       = aws_ses_domain_identity.domain.arn
+  description = "SES domain identity ARN"
+}

--- a/infrastructure/ses/variables.tf
+++ b/infrastructure/ses/variables.tf
@@ -1,0 +1,28 @@
+variable "domain" {
+  description = "Domain for SES identity"
+  type        = string
+}
+
+variable "template_name" {
+  description = "Name of the default email template"
+  type        = string
+  default     = "default"
+}
+
+variable "template_subject" {
+  description = "Subject line for the default template"
+  type        = string
+  default     = "Notification"
+}
+
+variable "template_html" {
+  description = "HTML body for the default template"
+  type        = string
+  default     = "<h1>Hello</h1>"
+}
+
+variable "template_text" {
+  description = "Text body for the default template"
+  type        = string
+  default     = "Hello"
+}

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -1,3 +1,18 @@
-# terraform
+# Terraform Scaffolding
 
-Infrastructure templates for terraform.
+This directory links together the individual infrastructure modules for a full deployment.
+
+## Usage
+```hcl
+module "stack" {
+  source             = "./infrastructure/terraform"
+  vpc_cidr           = "10.0.0.0/16"
+  vpc_name           = "demo"
+  public_subnets     = ["10.0.1.0/24"]
+  private_subnets    = ["10.0.101.0/24"]
+  availability_zones = ["us-east-1a"]
+  artifacts_bucket   = "demo-artifacts"
+}
+```
+
+Run `terraform init` then `terraform plan` to verify.

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,0 +1,13 @@
+module "vpc" {
+  source             = "../vpc"
+  vpc_cidr           = var.vpc_cidr
+  vpc_name           = var.vpc_name
+  public_subnets     = var.public_subnets
+  private_subnets    = var.private_subnets
+  availability_zones = var.availability_zones
+}
+
+module "artifacts" {
+  source      = "../artifacts"
+  bucket_name = var.artifacts_bucket
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,0 +1,6 @@
+variable "vpc_cidr" { type = string }
+variable "vpc_name" { type = string }
+variable "public_subnets" { type = list(string) }
+variable "private_subnets" { type = list(string) }
+variable "availability_zones" { type = list(string) }
+variable "artifacts_bucket" { type = string }

--- a/packages/codegen-templates/README.md
+++ b/packages/codegen-templates/README.md
@@ -1,0 +1,11 @@
+# Codegen Templates
+
+This package contains reusable templates for the code generation service.
+
+## CLI
+
+Run `pnpm codegen` to list available templates:
+
+```bash
+pnpm exec ts-node packages/codegen-templates/src/cli.ts
+```

--- a/packages/codegen-templates/package.json
+++ b/packages/codegen-templates/package.json
@@ -1,4 +1,10 @@
 {
   "name": "codegen-templates",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "bin": {
+    "codegen": "./src/cli.ts"
+  },
+  "dependencies": {
+    "commander": "^11.0.0"
+  }
 }

--- a/packages/codegen-templates/src/cli.ts
+++ b/packages/codegen-templates/src/cli.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { templates } from "./templates";
+
+const program = new Command();
+program
+  .name("codegen")
+  .description("List available code generation templates")
+  .action(() => {
+    for (const t of templates) {
+      console.log(`${t.name} - ${t.description}`);
+    }
+  });
+
+program.parse(process.argv);

--- a/packages/codegen-templates/src/templates/index.ts
+++ b/packages/codegen-templates/src/templates/index.ts
@@ -1,0 +1,5 @@
+export const templates = [
+  { name: "auth", description: "Basic authentication flow" },
+  { name: "crud", description: "CRUD boilerplate" },
+  { name: "chat", description: "ChatGPT integration" }
+];

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,4 +1,8 @@
 {
   "name": "shared",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.599.0",
+    "@aws-sdk/lib-dynamodb": "^3.599.0"
+  }
 }

--- a/packages/shared/src/README.md
+++ b/packages/shared/src/README.md
@@ -1,3 +1,7 @@
 # shared
 
 Shared library code.
+
+## DynamoDB Helpers
+
+This package now includes `putItem` and `getItem` helpers built on the AWS SDK v3 `DynamoDBDocumentClient`.

--- a/packages/shared/src/dynamo.ts
+++ b/packages/shared/src/dynamo.ts
@@ -1,0 +1,14 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+
+const client = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(client);
+
+export async function putItem(table: string, item: Record<string, any>) {
+  await docClient.send(new PutCommand({ TableName: table, Item: item }));
+}
+
+export async function getItem<T>(table: string, key: Record<string, any>): Promise<T | undefined> {
+  const res = await docClient.send(new GetCommand({ TableName: table, Key: key }));
+  return res.Item as T | undefined;
+}

--- a/services/analytics/README.md
+++ b/services/analytics/README.md
@@ -1,0 +1,10 @@
+# Analytics Service
+
+Simple Express server to record usage events and provide basic metrics.
+
+## Endpoints
+
+- `POST /events` – record an event payload
+- `GET /metrics` – return number of recorded events
+
+Run with `node dist/index.js` after building.

--- a/services/analytics/package.json
+++ b/services/analytics/package.json
@@ -1,4 +1,7 @@
 {
   "name": "analytics-service",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
 }

--- a/services/analytics/src/index.ts
+++ b/services/analytics/src/index.ts
@@ -1,0 +1,36 @@
+import express from "express";
+import fs from "fs";
+
+const app = express();
+app.use(express.json());
+
+const DB_FILE = process.env.EVENT_DB || ".events.json";
+
+function readEvents(): any[] {
+  if (!fs.existsSync(DB_FILE)) return [];
+  return JSON.parse(fs.readFileSync(DB_FILE, "utf-8"));
+}
+
+function saveEvents(events: any[]) {
+  fs.writeFileSync(DB_FILE, JSON.stringify(events, null, 2));
+}
+
+app.post("/events", (req, res) => {
+  const events = readEvents();
+  events.push({ ...req.body, time: Date.now() });
+  saveEvents(events);
+  res.status(201).json({ ok: true });
+});
+
+app.get("/metrics", (_req, res) => {
+  const events = readEvents();
+  res.json({ count: events.length });
+});
+
+export function start(port = 3001) {
+  app.listen(port, () => console.log(`analytics listening on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3001);
+}

--- a/services/email/README.md
+++ b/services/email/README.md
@@ -1,0 +1,17 @@
+# Email Service
+
+Provides helper functions for sending templated emails via Amazon SES.
+
+## Usage
+
+Set `EMAIL_DOMAIN` in your environment and call `sendEmail`:
+
+```ts
+import { sendEmail } from "email-service";
+
+await sendEmail({
+  template: "build",
+  to: "user@example.com",
+  data: { project: "Demo" }
+});
+```

--- a/services/email/package.json
+++ b/services/email/package.json
@@ -1,4 +1,7 @@
 {
   "name": "email-service",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "dependencies": {
+    "@aws-sdk/client-ses": "^3.599.0"
+  }
 }

--- a/services/email/src/index.ts
+++ b/services/email/src/index.ts
@@ -1,0 +1,19 @@
+import { SESClient, SendTemplatedEmailCommand } from "@aws-sdk/client-ses";
+
+const ses = new SESClient({});
+
+export interface SendOptions {
+  template: string;
+  to: string;
+  data: Record<string, string>;
+}
+
+export async function sendEmail(opts: SendOptions) {
+  const command = new SendTemplatedEmailCommand({
+    Destination: { ToAddresses: [opts.to] },
+    Source: `no-reply@${process.env.EMAIL_DOMAIN}`,
+    Template: opts.template,
+    TemplateData: JSON.stringify(opts.data),
+  });
+  return ses.send(command);
+}


### PR DESCRIPTION
## Summary
- create IAM, Cognito, SES, Observability and Terraform modules
- add SES email helper service
- implement simple analytics event API
- extend shared package with DynamoDB helpers
- provide codegen template CLI
- update repository README

## Testing
- `node -v`
- `terraform --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8ca1b8788331880c7fbbe55eba0c