### PR TITLE
Add orchestrator endpoints and portal pages

### DIFF
--- a/apps/api-auth/src/index.ts
+++ b/apps/api-auth/src/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { putItem, getItem } from "../../packages/shared/src/dynamo";
+import { initSentry } from "../../packages/shared/src/sentry";
 
 const app = express();
 app.use(express.json());
@@ -42,6 +43,7 @@ app.post('/verify', async (req, res) => {
 });
 
 export function start(port = 3000) {
+  initSentry('api-auth');
   app.listen(port, () => console.log(`auth listening on ${port}`));
 }
 

--- a/apps/codegen/package.json
+++ b/apps/codegen/package.json
@@ -1,6 +1,9 @@
 {
   "name": "codegen",
   "version": "0.1.0",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
   "scripts": {
     "build": "echo building codegen",
     "lint": "echo linting codegen",

--- a/apps/codegen/src/README.md
+++ b/apps/codegen/src/README.md
@@ -7,3 +7,7 @@ Start the service with:
 pnpm install
 node apps/codegen/src/index.ts
 ```
+
+## Endpoint
+
+- `POST /generate` – invoked by the orchestrator to generate code. Retries are handled using the `retry` helper.

--- a/apps/codegen/src/index.ts
+++ b/apps/codegen/src/index.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+import { retry } from '../../packages/retry/src';
+import { initSentry } from '../../packages/shared/src/sentry';
+
+const app = express();
+app.use(express.json());
+
+app.post('/generate', async (req, res) => {
+  const { jobId, description } = req.body;
+  console.log('generating code for', jobId, description);
+  await retry(async () => {
+    // placeholder for real generation logic
+    if (!description) throw new Error('invalid');
+  });
+  res.json({ ok: true });
+});
+
+export function start(port = 3003) {
+  initSentry('codegen');
+  app.listen(port, () => console.log(`codegen listening on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3003);
+}

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,10 @@
 {
   "name": "orchestrator",
   "version": "0.1.0",
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2"
+  },
   "scripts": {
     "build": "echo building orchestrator",
     "lint": "echo linting orchestrator",

--- a/apps/orchestrator/src/README.md
+++ b/apps/orchestrator/src/README.md
@@ -6,3 +6,8 @@ Coordinates code generation jobs and deployments.
 pnpm install
 node apps/orchestrator/src/index.ts
 ```
+
+## Endpoints
+
+- `POST /api/createApp` – start a new code generation job. Body: `{ "description": "my idea" }`. Returns a `jobId`.
+- `GET /api/status/:id` – retrieve the current status of a job.

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -1,0 +1,56 @@
+import express from 'express';
+import { randomUUID } from 'crypto';
+import fetch from 'node-fetch';
+import { putItem, getItem } from '../../packages/shared/src/dynamo';
+import { initSentry } from '../../packages/shared/src/sentry';
+
+const app = express();
+app.use(express.json());
+
+const JOBS_TABLE = process.env.JOBS_TABLE || 'jobs';
+const CODEGEN_URL = process.env.CODEGEN_URL || 'http://localhost:3002/generate';
+
+interface Job {
+  id: string;
+  description: string;
+  status: 'queued' | 'running' | 'complete' | 'failed';
+}
+
+async function dispatchJob(job: Job) {
+  try {
+    await putItem(JOBS_TABLE, { ...job, status: 'running' });
+    await fetch(CODEGEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jobId: job.id, description: job.description })
+    });
+    await putItem(JOBS_TABLE, { ...job, status: 'complete' });
+  } catch (err) {
+    await putItem(JOBS_TABLE, { ...job, status: 'failed' });
+  }
+}
+
+app.post('/api/createApp', async (req, res) => {
+  const { description } = req.body;
+  if (!description) return res.status(400).json({ error: 'missing description' });
+  const id = randomUUID();
+  const job: Job = { id, description, status: 'queued' };
+  await putItem(JOBS_TABLE, job);
+  dispatchJob(job); // fire and forget
+  res.status(202).json({ jobId: id });
+});
+
+app.get('/api/status/:id', async (req, res) => {
+  const job = await getItem<Job>(JOBS_TABLE, { id: req.params.id });
+  if (!job) return res.status(404).json({ error: 'not found' });
+  res.json(job);
+});
+
+export function start(port = 3002) {
+  initSentry('orchestrator');
+  app.listen(port, () => console.log(`orchestrator listening on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3002);
+}

--- a/apps/portal/src/README.md
+++ b/apps/portal/src/README.md
@@ -10,3 +10,7 @@ pnpm next dev --dir apps/portal/src
 ```
 
 Pages are located under `src/pages`.
+
+Additional pages:
+- `create.tsx` – simple form to submit an app description and receive a job ID.
+- `status.tsx` – check the current status of a code generation job.

--- a/apps/portal/src/pages/create.tsx
+++ b/apps/portal/src/pages/create.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+export default function CreateApp() {
+  const [description, setDescription] = useState('');
+  const [jobId, setJobId] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('http://localhost:3002/api/createApp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description })
+    });
+    const data = await res.json();
+    setJobId(data.jobId);
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <h1>New App</h1>
+        <textarea value={description} onChange={e => setDescription(e.target.value)} />
+        <button type="submit">Create</button>
+      </form>
+      {jobId && <p>Job submitted: {jobId}</p>}
+    </div>
+  );
+}

--- a/apps/portal/src/pages/status.tsx
+++ b/apps/portal/src/pages/status.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+export default function Status() {
+  const [jobId, setJobId] = useState('');
+  const [status, setStatus] = useState('');
+
+  async function checkStatus() {
+    const res = await fetch(`http://localhost:3002/api/status/${jobId}`);
+    if (res.ok) {
+      const data = await res.json();
+      setStatus(data.status);
+    }
+  }
+
+  return (
+    <div>
+      <h1>Check Job Status</h1>
+      <input value={jobId} onChange={e => setJobId(e.target.value)} placeholder="job id" />
+      <button onClick={checkStatus}>Check</button>
+      {status && <p>Status: {status}</p>}
+    </div>
+  );
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.599.0",
-    "@aws-sdk/lib-dynamodb": "^3.599.0"
+    "@aws-sdk/lib-dynamodb": "^3.599.0",
+    "@sentry/node": "^7.88.0"
   },
   "scripts": {
     "build": "echo building shared",

--- a/packages/shared/src/README.md
+++ b/packages/shared/src/README.md
@@ -5,3 +5,7 @@ Shared library code.
 ## DynamoDB Helpers
 
 This package now includes `putItem` and `getItem` helpers built on the AWS SDK v3 `DynamoDBDocumentClient`.
+
+## Sentry
+
+`initSentry(serviceName)` initializes Sentry if a `SENTRY_DSN` environment variable is provided.

--- a/packages/shared/src/sentry.ts
+++ b/packages/shared/src/sentry.ts
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/node';
+
+export function initSentry(service: string) {
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return;
+  Sentry.init({ dsn, tracesSampleRate: 1.0, environment: service });
+}

--- a/services/analytics/src/index.ts
+++ b/services/analytics/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import fs from "fs";
+import { initSentry } from "../../packages/shared/src/sentry";
 
 const app = express();
 app.use(express.json());
@@ -28,6 +29,7 @@ app.get("/metrics", (_req, res) => {
 });
 
 export function start(port = 3001) {
+  initSentry('analytics');
   app.listen(port, () => console.log(`analytics listening on ${port}`));
 }
 

--- a/services/email/src/index.ts
+++ b/services/email/src/index.ts
@@ -1,5 +1,7 @@
 import { SESClient, SendTemplatedEmailCommand } from "@aws-sdk/client-ses";
+import { initSentry } from "../../packages/shared/src/sentry";
 
+initSentry('email');
 const ses = new SESClient({});
 
 export interface SendOptions {

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -25,3 +25,9 @@ This file records brief summaries of each pull request.
 - Added CloudWatch dashboard resource to observability module.
 - Expanded README files and added dev/deploy helper scripts.
 - Updated task tracking to mark completed items.
+
+## PR <pending> - Implement orchestrator API and portal pages
+- Added `/api/createApp` and `/api/status` endpoints in the orchestrator with DynamoDB persistence.
+- Created simple codegen service using the retry helper.
+- Added portal pages for submitting descriptions and checking build status.
+- Updated READMEs and marked related tasks as completed.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -12,9 +12,9 @@
 |8|JWT session management|Completed|
 |9|Connect user data store|Completed|
 |10|Email verification endpoint|Completed|
-|11|/api/createApp endpoint|Not Started|
-|12|Dispatch CodeGen jobs|Not Started|
-|13|Persist job status in DynamoDB|Not Started|
+|11|/api/createApp endpoint|Completed|
+|12|Dispatch CodeGen jobs|Completed|
+|13|Persist job status in DynamoDB|Completed|
 |14|Trigger deployments|Not Started|
 |15|Send notification emails|Not Started|
 |16|Integrate OpenAI API|Not Started|
@@ -26,8 +26,8 @@
 |22|Collect usage events|Completed|
 |23|Metrics API|Completed|
 |24|Portal login/signup|Completed|
-|25|Create New App wizard|Not Started|
-|26|Show build status|Not Started|
+|25|Create New App wizard|Completed|
+|26|Show build status|Completed|
 |27|List user apps|Not Started|
 |28|Editing descriptions triggers redeploys|Not Started|
 |29|Shared AWS helpers|Completed|
@@ -36,7 +36,7 @@
 |32|GitHub Actions|Completed|
 |33|Remote caching|Completed|
 |34|CloudWatch dashboards|Completed|
-|35|Sentry integration|Not Started|
+|35|Sentry integration|Completed|
 |36|Unit tests for each service|Not Started|
 |37|End-to-end tests|Not Started|
 |38|Static analysis|Not Started|


### PR DESCRIPTION
## Summary
- implement orchestrator service with `/api/createApp` and `/api/status`
- add simple codegen service using retry helper
- create portal pages to submit app descriptions and view job status
- integrate Sentry across services
- update docs and task tracking

## Testing
- `pnpm run build` *(fails: turbo not found)*
- `pnpm run lint` *(fails: turbo not found)*
- `pnpm run test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9784aa488331b2f0a009237a4201