### PR TITLE
Add CODEOWNERS, bootstrap scripts, and docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for each folder
+/apps/api-auth @maintainer1
+/apps/orchestrator @maintainer2
+/apps/codegen @maintainer3
+/apps/portal @maintainer4
+/services/email @maintainer5
+/services/analytics @maintainer6
+/infrastructure @infra-team
+/tools @dev-tools

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ node services/analytics/src/index.ts &
 ```
 
 Infrastructure modules live under `infrastructure/`. Initialize them with `terraform init`.
+
+Local services can also be started via `docker-compose up`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  dynamodb:
+    image: amazon/dynamodb-local
+    ports:
+      - '8000:8000'
+  localstack:
+    image: localstack/localstack
+    ports:
+      - '4566:4566'

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,14 @@
+# Infrastructure Modules
+
+This folder contains Terraform modules used to provision cloud resources for the platform.
+
+## Deployment
+
+Run the following commands from this directory to deploy the infrastructure:
+
+```bash
+terraform init
+terraform plan
+```
+
+Apply the plan with `terraform apply` when you're ready to create or update resources.

--- a/packages/shared/src/README.md
+++ b/packages/shared/src/README.md
@@ -4,7 +4,12 @@ Shared library code.
 
 ## DynamoDB Helpers
 
-This package now includes `putItem` and `getItem` helpers built on the AWS SDK v3 `DynamoDBDocumentClient`.
+This package now includes DynamoDB helper functions built on the AWS SDK v3 `DynamoDBDocumentClient`:
+
+- `putItem`
+- `getItem`
+- `updateItem`
+- `queryItems`
 
 ## Sentry
 

--- a/packages/shared/src/dynamo.ts
+++ b/packages/shared/src/dynamo.ts
@@ -1,5 +1,11 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
 
 const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
@@ -11,4 +17,27 @@ export async function putItem(table: string, item: Record<string, any>) {
 export async function getItem<T>(table: string, key: Record<string, any>): Promise<T | undefined> {
   const res = await docClient.send(new GetCommand({ TableName: table, Key: key }));
   return res.Item as T | undefined;
+}
+
+export async function updateItem(table: string, key: Record<string, any>, updateExp: string, values: Record<string, any>) {
+  await docClient.send(
+    new UpdateCommand({
+      TableName: table,
+      Key: key,
+      UpdateExpression: updateExp,
+      ExpressionAttributeValues: values,
+    })
+  );
+}
+
+export async function queryItems<T>(table: string, index: string, keyCondExp: string, values: Record<string, any>): Promise<T[]> {
+  const res = await docClient.send(
+    new QueryCommand({
+      TableName: table,
+      IndexName: index,
+      KeyConditionExpression: keyCondExp,
+      ExpressionAttributeValues: values,
+    })
+  );
+  return (res.Items as T[]) || [];
 }

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -31,3 +31,8 @@ This file records brief summaries of each pull request.
 - Created simple codegen service using the retry helper.
 - Added portal pages for submitting descriptions and checking build status.
 - Updated READMEs and marked related tasks as completed.
+
+## PR <pending> - Documentation and tooling updates
+- Added CODEOWNERS file and docker-compose setup.
+- Created bootstrap-service script and k6 load test example.
+- Documented infrastructure deployment and updated shared DynamoDB helpers.

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,3 +4,6 @@ Utility scripts for local development and deployment.
 
 - `dev.sh` – start core services for testing
 - `deploy.sh` – run `terraform plan` across infrastructure modules
+- `bootstrap-service.sh` – create a new service folder with starter files
+
+- `loadtest/basic.js` – example k6 script

--- a/tools/bootstrap-service.sh
+++ b/tools/bootstrap-service.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Create a new service folder with basic scaffolding.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <service-name>" >&2
+  exit 1
+fi
+
+NAME=$1
+dir="services/$NAME"
+
+mkdir -p "$dir/src"
+cat <<'EOS' > "$dir/package.json"
+{
+  "name": "$NAME",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "echo building $NAME",
+    "lint": "echo linting $NAME",
+    "test": "echo testing $NAME"
+  }
+}
+EOS
+cat <<'EOS' > "$dir/src/index.ts"
+export function handler() {
+  console.log('Service $NAME ready');
+}
+EOS
+
+printf "Created %s" "$dir"

--- a/tools/loadtest/README.md
+++ b/tools/loadtest/README.md
@@ -1,0 +1,9 @@
+# Load Testing
+
+This directory contains k6 scripts used to measure system performance.
+
+Run a test with:
+
+```bash
+k6 run basic.js
+```

--- a/tools/loadtest/basic.js
+++ b/tools/loadtest/basic.js
@@ -1,0 +1,7 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export default function () {
+  http.get('http://localhost:3000/health');
+  sleep(1);
+}


### PR DESCRIPTION
## Summary
- add CODEOWNERS file for repository governance
- document infrastructure deployment steps
- provide docker-compose for local services
- add bootstrap-service script and load testing example
- expand DynamoDB helpers in shared package
- update steps summary

## Testing
- `pnpm install`
- `pnpm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9cab37108331864f4227e38376f6