### PR TITLE
Implement deployment hooks and app listing

### DIFF
--- a/apps/orchestrator/src/README.md
+++ b/apps/orchestrator/src/README.md
@@ -11,3 +11,8 @@ node apps/orchestrator/src/index.ts
 
 - `POST /api/createApp` – start a new code generation job. Body: `{ "description": "my idea" }`. Returns a `jobId`.
 - `GET /api/status/:id` – retrieve the current status of a job.
+- `GET /api/apps` – list all generated apps.
+- `POST /api/redeploy/:id` – submit a new description to redeploy an existing app.
+
+Set `DEPLOY_URL` to the deployment webhook and `NOTIFY_EMAIL` to receive job
+notifications.

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -1,14 +1,17 @@
 import express from 'express';
 import { randomUUID } from 'crypto';
 import fetch from 'node-fetch';
-import { putItem, getItem } from '../../packages/shared/src/dynamo';
+import { putItem, getItem, scanTable } from '../../packages/shared/src/dynamo';
+import { sendEmail } from '../../services/email/src';
 import { initSentry } from '../../packages/shared/src/sentry';
 
 const app = express();
 app.use(express.json());
 
 const JOBS_TABLE = process.env.JOBS_TABLE || 'jobs';
-const CODEGEN_URL = process.env.CODEGEN_URL || 'http://localhost:3002/generate';
+const CODEGEN_URL = process.env.CODEGEN_URL || 'http://localhost:3003/generate';
+const DEPLOY_URL = process.env.DEPLOY_URL;
+const NOTIFY_EMAIL = process.env.NOTIFY_EMAIL;
 
 interface Job {
   id: string;
@@ -16,17 +19,43 @@ interface Job {
   status: 'queued' | 'running' | 'complete' | 'failed';
 }
 
+async function triggerDeploy(jobId: string) {
+  if (!DEPLOY_URL) {
+    console.log('deploy url not configured, skipping deploy');
+    return;
+  }
+  try {
+    await fetch(DEPLOY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jobId }),
+    });
+  } catch (err) {
+    console.error('deploy failed', err);
+  }
+}
+
 async function dispatchJob(job: Job) {
   try {
     await putItem(JOBS_TABLE, { ...job, status: 'running' });
+    if (NOTIFY_EMAIL) {
+      sendEmail({ template: 'job-start', to: NOTIFY_EMAIL, data: { id: job.id } });
+    }
     await fetch(CODEGEN_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ jobId: job.id, description: job.description })
     });
     await putItem(JOBS_TABLE, { ...job, status: 'complete' });
+    await triggerDeploy(job.id);
+    if (NOTIFY_EMAIL) {
+      sendEmail({ template: 'job-complete', to: NOTIFY_EMAIL, data: { id: job.id } });
+    }
   } catch (err) {
     await putItem(JOBS_TABLE, { ...job, status: 'failed' });
+    if (NOTIFY_EMAIL) {
+      sendEmail({ template: 'job-failed', to: NOTIFY_EMAIL, data: { id: job.id } });
+    }
   }
 }
 
@@ -44,6 +73,21 @@ app.get('/api/status/:id', async (req, res) => {
   const job = await getItem<Job>(JOBS_TABLE, { id: req.params.id });
   if (!job) return res.status(404).json({ error: 'not found' });
   res.json(job);
+});
+
+app.get('/api/apps', async (_req, res) => {
+  const jobs = await scanTable<Job>(JOBS_TABLE);
+  res.json(jobs);
+});
+
+app.post('/api/redeploy/:id', async (req, res) => {
+  const { description } = req.body;
+  if (!description) return res.status(400).json({ error: 'missing description' });
+  const id = req.params.id;
+  const job: Job = { id, description, status: 'queued' };
+  await putItem(JOBS_TABLE, job);
+  dispatchJob(job);
+  res.status(202).json({ jobId: id });
 });
 
 export function start(port = 3002) {

--- a/apps/portal/src/README.md
+++ b/apps/portal/src/README.md
@@ -14,3 +14,4 @@ Pages are located under `src/pages`.
 Additional pages:
 - `create.tsx` – simple form to submit an app description and receive a job ID.
 - `status.tsx` – check the current status of a code generation job.
+- `apps.tsx` – list all generated apps and their current status.

--- a/apps/portal/src/pages/apps.tsx
+++ b/apps/portal/src/pages/apps.tsx
@@ -1,0 +1,17 @@
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function Apps() {
+  const { data } = useSWR('http://localhost:3002/api/apps', fetcher);
+  return (
+    <div>
+      <h1>Your Apps</h1>
+      <ul>
+        {data?.map((app: any) => (
+          <li key={app.id}>{app.description} - {app.status}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -12,3 +12,16 @@ terraform plan
 ```
 
 Apply the plan with `terraform apply` when you're ready to create or update resources.
+
+Each subfolder under `infrastructure/` represents a reusable module. Before
+running the commands above ensure your AWS credentials are configured and any
+required variables are set either via `terraform.tfvars` or environment
+variables.
+
+Example for the VPC module:
+
+```bash
+cd vpc
+terraform init
+terraform plan -var-file=example.tfvars
+```

--- a/packages/shared/src/dynamo.ts
+++ b/packages/shared/src/dynamo.ts
@@ -5,6 +5,7 @@ import {
   PutCommand,
   UpdateCommand,
   QueryCommand,
+  ScanCommand,
 } from "@aws-sdk/lib-dynamodb";
 
 const client = new DynamoDBClient({});
@@ -39,5 +40,10 @@ export async function queryItems<T>(table: string, index: string, keyCondExp: st
       ExpressionAttributeValues: values,
     })
   );
+  return (res.Items as T[]) || [];
+}
+
+export async function scanTable<T>(table: string): Promise<T[]> {
+  const res = await docClient.send(new ScanCommand({ TableName: table }));
   return (res.Items as T[]) || [];
 }

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -36,3 +36,12 @@ This file records brief summaries of each pull request.
 - Added CODEOWNERS file and docker-compose setup.
 - Created bootstrap-service script and k6 load test example.
 - Documented infrastructure deployment and updated shared DynamoDB helpers.
+
+## PR <pending> - Deployment triggers and app listing
+- Orchestrator now calls a deployment webhook and sends notification emails when
+jobs start, complete or fail.
+- Added endpoints `/api/apps` and `/api/redeploy/:id` with corresponding portal
+page and CLI tool.
+- Implemented `scanTable` helper in shared package and updated infrastructure
+docs.
+- Updated task tracking to mark related items as completed.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -15,8 +15,8 @@
 |11|/api/createApp endpoint|Completed|
 |12|Dispatch CodeGen jobs|Completed|
 |13|Persist job status in DynamoDB|Completed|
-|14|Trigger deployments|Not Started|
-|15|Send notification emails|Not Started|
+|14|Trigger deployments|Completed|
+|15|Send notification emails|Completed|
 |16|Integrate OpenAI API|Not Started|
 |17|Isolated generation tasks|Not Started|
 |18|Run lint/unit tests|Not Started|
@@ -28,8 +28,8 @@
 |24|Portal login/signup|Completed|
 |25|Create New App wizard|Completed|
 |26|Show build status|Completed|
-|27|List user apps|Not Started|
-|28|Editing descriptions triggers redeploys|Not Started|
+|27|List user apps|Completed|
+|28|Editing descriptions triggers redeploys|Completed|
 |29|Shared AWS helpers|Completed|
 |30|Codegen template library|Completed|
 |31|Turborepo/Nx tasks|Completed|
@@ -48,4 +48,5 @@
 |44|Static site hosting module|Completed|
 |45|PostgreSQL templates|Completed|
 |46|Secrets management|Completed|
+|69|Infrastructure Deployment Guide|Completed|
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,5 +5,12 @@ Utility scripts for local development and deployment.
 - `dev.sh` – start core services for testing
 - `deploy.sh` – run `terraform plan` across infrastructure modules
 - `bootstrap-service.sh` – create a new service folder with starter files
+- `redeploy.js` – CLI to update descriptions and trigger redeployments
 
 - `loadtest/basic.js` – example k6 script
+
+### Redeploy Example
+
+```
+node tools/redeploy.js --id abc123 --description "New features" --url http://localhost:3002
+```

--- a/tools/redeploy.js
+++ b/tools/redeploy.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const { Command } = require('commander');
+const fetch = require('node-fetch');
+
+const program = new Command();
+program
+  .requiredOption('-i, --id <id>', 'existing job id')
+  .requiredOption('-d, --description <desc>', 'new description')
+  .option('-u, --url <url>', 'orchestrator url', 'http://localhost:3002');
+
+program.parse(process.argv);
+const opts = program.opts();
+
+(async () => {
+  const res = await fetch(`${opts.url}/api/redeploy/${opts.id}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ description: opts.description })
+  });
+  if (!res.ok) {
+    console.error(`Redeploy failed: ${res.status}`);
+    process.exit(1);
+  }
+  console.log('Redeploy triggered for', opts.id);
+})();


### PR DESCRIPTION
## Summary
- add scanTable helper for DynamoDB
- orchestrator triggers deployments and sends notification emails
- expose `/api/apps` and `/api/redeploy/:id` endpoints
- add portal page listing apps
- provide CLI for redeploying existing apps
- expand infrastructure deployment docs
- update task tracking and summary

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686aa0c3f3fc8331b414ab8139d95d20