### PR TITLE
Add schema persistence and voice modeling parser

### DIFF
--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -26,6 +26,7 @@ const NOTIFY_EMAIL = process.env.NOTIFY_EMAIL;
 const ARTIFACTS_BUCKET = process.env.ARTIFACTS_BUCKET;
 const TENANT_HEADER = 'x-tenant-id';
 const WORKFLOW_FILE = process.env.WORKFLOW_FILE || 'workflow.json';
+const SCHEMA_FILE = process.env.SCHEMA_FILE || 'schema.json';
 
 export interface Job {
   id: string;
@@ -117,6 +118,16 @@ app.get('/api/workflow', (_req, res) => {
 
 app.post('/api/workflow', (req, res) => {
   fs.writeFileSync(WORKFLOW_FILE, JSON.stringify(req.body, null, 2));
+  res.json({ ok: true });
+});
+
+app.get('/api/schema', (_req, res) => {
+  if (!fs.existsSync(SCHEMA_FILE)) return res.json({});
+  res.json(JSON.parse(fs.readFileSync(SCHEMA_FILE, 'utf-8')));
+});
+
+app.post('/api/schema', (req, res) => {
+  fs.writeFileSync(SCHEMA_FILE, JSON.stringify(req.body, null, 2));
   res.json({ ok: true });
 });
 

--- a/apps/portal/src/pages/voice-modeling.tsx
+++ b/apps/portal/src/pages/voice-modeling.tsx
@@ -1,12 +1,42 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
+
+interface Table {
+  name: string;
+  fields: { name: string; type: string }[];
+}
 
 export default function VoiceModeling() {
   const [transcript, setTranscript] = useState('');
+  const [tables, setTables] = useState<Table[]>([]);
   const recRef = useRef<any>();
+
+  function parse(text: string): Table[] {
+    const words = text.toLowerCase().split(/\s+/);
+    const result: Table[] = [];
+    let i = 0;
+    while (i < words.length) {
+      if (words[i] === 'table') {
+        const name = words[i + 1];
+        i += 2;
+        const fields: { name: string; type: string }[] = [];
+        while (i < words.length && words[i] !== 'table') {
+          const field = words[i];
+          const type = words[i + 1] || 'string';
+          fields.push({ name: field, type });
+          i += 2;
+        }
+        result.push({ name, fields });
+      } else {
+        i++;
+      }
+    }
+    return result;
+  }
 
   const start = () => {
     const SpeechRecognition =
-      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+      (window as any).SpeechRecognition ||
+      (window as any).webkitSpeechRecognition;
     if (!SpeechRecognition) return alert('Speech API not supported');
     const rec = new SpeechRecognition();
     rec.onresult = (e: any) => {
@@ -21,12 +51,28 @@ export default function VoiceModeling() {
 
   const stop = () => recRef.current?.stop();
 
+  useEffect(() => {
+    const parsed = parse(transcript);
+    setTables(parsed);
+  }, [transcript]);
+
+  const save = async () => {
+    await fetch('/api/schema', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tables }),
+    });
+    alert('schema saved');
+  };
+
   return (
     <div style={{ padding: 20 }}>
       <h1>Voice Guided Modeling</h1>
       <button onClick={start}>Start</button>
       <button onClick={stop}>Stop</button>
       <pre>{transcript}</pre>
+      <pre>{JSON.stringify(tables, null, 2)}</pre>
+      <button onClick={save}>Save Schema</button>
     </div>
   );
 }

--- a/docs/voice-modeling.md
+++ b/docs/voice-modeling.md
@@ -1,3 +1,17 @@
 # Voice-Guided Data Modeling
 
-The `voice-modeling` page captures speech via the Web Speech API and displays the transcribed text. Use this to quickly draft data models before refining them in the schema designer.
+The `voice-modeling` page captures speech via the Web Speech API and converts simple commands into table definitions. Saying for example
+
+```
+table users id int name string
+table posts id int title string
+```
+
+will produce a schema with two tables and the specified fields. The parsed schema can be saved via the "Save Schema" button which POSTs to `/api/schema` in the orchestrator.
+
+Supported keywords:
+
+- `table <name>` – start a new table
+- `<field> <type>` – add field and type until the next `table`
+
+Results are stored in `schema.json` server side and can be loaded by the schema designer.

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -165,3 +165,4 @@ This file records brief summaries of each pull request.
 - Implemented A/B testing endpoints in the analytics service with file persistence and tests.
 - Marketplace now exposes `/templates`; workflow builder uses React Flow.
 - Introduced i18n helpers, region policy middleware and AWS cost optimization script.
+- Added schema persistence endpoints and enhanced voice modeling with table parsing.


### PR DESCRIPTION
## Summary
- store schemas using new `/api/schema` endpoints in the orchestrator
- parse voice modeling transcripts into tables and save schema
- document supported voice commands
- note latest change in `steps_summary.md`

## Testing
- `npx prettier -w apps/orchestrator/src/index.ts apps/orchestrator/src/index.test.ts apps/portal/src/pages/voice-modeling.tsx docs/voice-modeling.md`
- `pnpm install` *(fails: ERR_PNPM_NO_MATCHING_VERSION)*
- `pnpm exec jest` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bfbc7db648331a4e9a263fcba6627