### PR TITLE
Add language-aware code generation

### DIFF
--- a/apps/codegen/src/customModel.ts
+++ b/apps/codegen/src/customModel.ts
@@ -11,7 +11,7 @@ export async function generateWithCustomModel(
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ prompt: opts.description }),
+    body: JSON.stringify({ prompt: opts.description, language: opts.language }),
   });
   if (!res.ok) {
     throw new Error(`Custom model request failed: ${res.status}`);

--- a/apps/codegen/src/index.test.ts
+++ b/apps/codegen/src/index.test.ts
@@ -1,8 +1,20 @@
 const request = require('supertest');
 jest.mock('node-fetch', () => jest.fn(async () => ({ ok: true, json: async () => ({ choices: [{ message: { content: 'code' } }] }) })));
+jest.mock('./openai', () => ({
+  generateCode: jest.fn(async () => 'code'),
+}));
 const { app } = require('./index');
+const { generateCode } = require('./openai');
 
 test('generate endpoint validates description', async () => {
   const res = await request(app).post('/generate').send({ jobId: '1' });
   expect(res.status).toBe(500);
+});
+
+test('forwards language option', async () => {
+  const res = await request(app)
+    .post('/generate')
+    .send({ jobId: '1', description: 'd', language: 'go' });
+  expect(res.status).toBe(200);
+  expect(generateCode).toHaveBeenCalledWith({ description: 'd', language: 'go' });
 });

--- a/apps/codegen/src/index.ts
+++ b/apps/codegen/src/index.ts
@@ -9,18 +9,19 @@ app.use(express.json());
 const cache = new Map<string, string>();
 
 app.post('/generate', async (req, res) => {
-  const { jobId, description } = req.body;
-  console.log('generating code for', jobId, description);
+  const { jobId, description, language = 'node' } = req.body;
+  console.log('generating code for', jobId, description, language);
   try {
-    if (description && cache.has(description)) {
-      return res.json({ ok: true, code: cache.get(description) });
+    const cacheKey = `${language}:${description}`;
+    if (description && cache.has(cacheKey)) {
+      return res.json({ ok: true, code: cache.get(cacheKey) });
     }
     const code = await retry(async () => {
       if (!description) throw new Error('invalid');
-      return generateCode({ description });
+      return generateCode({ description, language });
     });
     if (description) {
-      cache.set(description, code);
+      cache.set(cacheKey, code);
     }
     res.json({ ok: true, code });
   } catch (err: any) {

--- a/apps/codegen/src/openai.ts
+++ b/apps/codegen/src/openai.ts
@@ -3,6 +3,7 @@ import { generateWithCustomModel } from './customModel';
 
 export interface GenerationOptions {
   description: string;
+  language: string;
 }
 
 export async function generateCode(opts: GenerationOptions): Promise<string> {
@@ -21,7 +22,12 @@ export async function generateCode(opts: GenerationOptions): Promise<string> {
     },
     body: JSON.stringify({
       model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: opts.description }],
+      messages: [
+        {
+          role: 'user',
+          content: `Generate a ${opts.language} project for: ${opts.description}`,
+        },
+      ],
     }),
   });
   if (!res.ok) {

--- a/apps/orchestrator/src/README.md
+++ b/apps/orchestrator/src/README.md
@@ -1,6 +1,7 @@
 # Orchestrator Service
 
-Coordinates code generation jobs and deployments.
+Coordinates code generation jobs and deployments. Jobs can target different
+backend languages.
 
 ```bash
 pnpm install
@@ -9,7 +10,8 @@ node apps/orchestrator/src/index.ts
 
 ## Endpoints
 
-- `POST /api/createApp` – start a new code generation job. Body: `{ "description": "my idea" }`. Returns a `jobId`.
+- `POST /api/createApp` – start a new code generation job. Body:
+  `{ "description": "my idea", "language": "node" }`. Returns a `jobId`.
 - `GET /api/status/:id` – retrieve the current status of a job.
 - `GET /api/apps` – list all generated apps.
 - `POST /api/redeploy/:id` – submit a new description to redeploy an existing app.

--- a/docs/multi-language.md
+++ b/docs/multi-language.md
@@ -1,3 +1,16 @@
 # Multi-Language Output
 
 Templates can target frameworks beyond Node.js. Support includes Python FastAPI services, Go Fiber apps and React Native mobile projects. The orchestrator selects templates based on the chosen language.
+
+## Choosing a Language
+
+On the **New App** page in the portal, select a language from the dropdown. The options are `node`, `fastapi` and `go`. This value is sent in the `language` field to `/api/createApp` and forwarded to the code generation service. You can also call the API directly:
+
+```bash
+curl -X POST http://localhost:3002/api/createApp \
+  -H 'Content-Type: application/json' \
+  -H 'x-tenant-id: t1' \
+  -d '{"description":"todo api","language":"go"}'
+```
+
+Generated code will match the selected runtime.

--- a/packages/codegen-templates/src/templates/index.ts
+++ b/packages/codegen-templates/src/templates/index.ts
@@ -3,6 +3,7 @@ export const templates = [
   { name: 'crud', description: 'CRUD boilerplate' },
   { name: 'chat', description: 'ChatGPT integration' },
   { name: 'graphql', description: 'GraphQL API builder' },
+  { name: 'node', description: 'Node.js Express boilerplate' },
   { name: 'fastapi', description: 'Python FastAPI boilerplate' },
   { name: 'go', description: 'Go REST API boilerplate' },
   { name: 'mobile', description: 'React Native starter app' },

--- a/packages/codegen-templates/src/templates/node/README.md
+++ b/packages/codegen-templates/src/templates/node/README.md
@@ -1,0 +1,3 @@
+# Node Template
+
+Express.js starter project with TypeScript.

--- a/packages/codegen-templates/src/templates/node/server.ts
+++ b/packages/codegen-templates/src/templates/node/server.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+const app = express();
+
+app.get('/', (_req, res) => {
+  res.send('hello');
+});
+
+app.listen(3000);

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -179,3 +179,8 @@ This file records brief summaries of each pull request.
 - Added `/api/connectors` GET, POST and DELETE routes in the orchestrator with DynamoDB persistence.
 - Portal connectors page now loads and saves connector keys via the API.
 - Documented available connectors and API usage in `edge-connectors.md`.
+
+## PR <pending> - Language-aware code generation
+- `generateCode` now accepts a `language` option and the codegen service caches results per language.
+- Added Node.js template and documented language selection in `multi-language.md`.
+- Orchestrator README updated with language field example.


### PR DESCRIPTION
## Summary
- add Node.js template and list available languages
- implement language option in codegen service and custom model
- update orchestrator docs and multi-language guide
- record changes in steps_summary

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c384e6c5083318a7f4582bf876de8