### PR TITLE
Implement plugin marketplace installation flow

### DIFF
--- a/apps/orchestrator/src/index.test.ts
+++ b/apps/orchestrator/src/index.test.ts
@@ -7,21 +7,26 @@ jest.mock('node-fetch', () =>
 
 const jobMem: Record<string, any> = {};
 const connMem: Record<string, any> = {};
+const pluginMem: Record<string, any> = {};
 jest.mock('../../packages/shared/src/dynamo', () => ({
   putItem: jest.fn(async (t: string, item: any) => {
     if (t === 'connectors') connMem[item.tenantId] = item;
+    else if (t === 'plugins') pluginMem[item.tenantId] = item;
     else jobMem[item.id] = item;
   }),
   getItem: jest.fn(async (t: string, key: any) => {
     if (t === 'connectors') return connMem[key.tenantId];
+    if (t === 'plugins') return pluginMem[key.tenantId];
     return jobMem[key.id];
   }),
   scanTable: jest.fn(async (t: string) => {
     if (t === 'connectors') return Object.values(connMem);
+    if (t === 'plugins') return Object.values(pluginMem);
     return Object.values(jobMem);
   }),
   deleteItem: jest.fn(async (t: string, key: any) => {
     if (t === 'connectors') delete connMem[key.tenantId];
+    else if (t === 'plugins') delete pluginMem[key.tenantId];
     else delete jobMem[key.id];
   }),
 }));
@@ -29,6 +34,7 @@ jest.mock('../../packages/shared/src/dynamo', () => ({
 afterEach(() => {
   for (const key of Object.keys(jobMem)) delete jobMem[key];
   for (const key of Object.keys(connMem)) delete connMem[key];
+  for (const key of Object.keys(pluginMem)) delete pluginMem[key];
 });
 
 test('status endpoint returns 404 for missing job', async () => {
@@ -107,12 +113,22 @@ test('connectors DELETE removes type', async () => {
     .post('/api/connectors')
     .set('x-tenant-id', 't1')
     .send({ stripeKey: 'sk', slackKey: 'sl' });
-  await request(app)
-    .delete('/api/connectors/stripe')
-    .set('x-tenant-id', 't1');
+  await request(app).delete('/api/connectors/stripe').set('x-tenant-id', 't1');
   const res = await request(app)
     .get('/api/connectors')
     .set('x-tenant-id', 't1');
   expect(res.body.stripeKey).toBeUndefined();
   expect(res.body.slackKey).toBe('sl');
+});
+
+test('plugins API installs and removes plugin', async () => {
+  await request(app)
+    .post('/api/plugins')
+    .set('x-tenant-id', 't1')
+    .send({ name: 'auth' });
+  let res = await request(app).get('/api/plugins').set('x-tenant-id', 't1');
+  expect(res.body).toContain('auth');
+  await request(app).delete('/api/plugins/auth').set('x-tenant-id', 't1');
+  res = await request(app).get('/api/plugins').set('x-tenant-id', 't1');
+  expect(res.body).not.toContain('auth');
 });

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -1,7 +1,12 @@
 import express from 'express';
 import { randomUUID } from 'crypto';
 import fetch from 'node-fetch';
-import { putItem, getItem, scanTable, deleteItem } from '../../packages/shared/src/dynamo';
+import {
+  putItem,
+  getItem,
+  scanTable,
+  deleteItem,
+} from '../../packages/shared/src/dynamo';
 import { uploadObject } from '../../packages/shared/src/s3';
 import { sendEmail } from '../../services/email/src';
 import { initSentry } from '../../packages/shared/src/sentry';
@@ -28,6 +33,9 @@ const TENANT_HEADER = 'x-tenant-id';
 const WORKFLOW_FILE = process.env.WORKFLOW_FILE || 'workflow.json';
 const SCHEMA_FILE = process.env.SCHEMA_FILE || 'schema.json';
 const CONNECTORS_TABLE = process.env.CONNECTORS_TABLE || 'connectors';
+const PLUGINS_TABLE = process.env.PLUGINS_TABLE || 'plugins';
+const PLUGIN_SERVICE_URL =
+  process.env.PLUGIN_SERVICE_URL || 'http://localhost:3006';
 
 export interface Job {
   id: string;
@@ -70,6 +78,13 @@ export async function dispatchJob(job: Job) {
         jobId: job.id,
         description: job.description,
         language: job.language,
+        plugins:
+          (
+            await getItem<{ tenantId: string; plugins: string[] }>(
+              PLUGINS_TABLE,
+              { tenantId: job.tenantId }
+            )
+          )?.plugins || [],
       }),
     });
     const { code } = await genRes.json();
@@ -161,11 +176,10 @@ app.get('/api/connectors', async (req, res) => {
 app.post('/api/connectors', async (req, res) => {
   const tenantId = req.header(TENANT_HEADER);
   if (!tenantId) return res.status(401).json({ error: 'missing tenant' });
-  const existing =
-    (await getItem<{ tenantId: string; config: Record<string, any> }>(
-      CONNECTORS_TABLE,
-      { tenantId }
-    )) || { tenantId, config: {} };
+  const existing = (await getItem<{
+    tenantId: string;
+    config: Record<string, any>;
+  }>(CONNECTORS_TABLE, { tenantId })) || { tenantId, config: {} };
   existing.config = { ...existing.config, ...req.body };
   await putItem(CONNECTORS_TABLE, existing);
   res.status(201).json({ ok: true });
@@ -182,6 +196,63 @@ app.delete('/api/connectors/:type', async (req, res) => {
     return res.status(404).json({ error: 'not found' });
   delete item.config[req.params.type];
   await putItem(CONNECTORS_TABLE, item);
+  res.json({ ok: true });
+});
+
+app.get('/api/plugins', async (req, res) => {
+  const tenantId = req.header(TENANT_HEADER);
+  if (!tenantId) return res.status(401).json({ error: 'missing tenant' });
+  const item = await getItem<{ tenantId: string; plugins: string[] }>(
+    PLUGINS_TABLE,
+    { tenantId }
+  );
+  res.json(item?.plugins || []);
+});
+
+app.post('/api/plugins', async (req, res) => {
+  const tenantId = req.header(TENANT_HEADER);
+  if (!tenantId) return res.status(401).json({ error: 'missing tenant' });
+  const name = req.body.name;
+  if (!name) return res.status(400).json({ error: 'missing name' });
+  const existing = (await getItem<{ tenantId: string; plugins: string[] }>(
+    PLUGINS_TABLE,
+    {
+      tenantId,
+    }
+  )) || { tenantId, plugins: [] };
+  if (!existing.plugins.includes(name)) existing.plugins.push(name);
+  await putItem(PLUGINS_TABLE, existing);
+  try {
+    await fetch(`${PLUGIN_SERVICE_URL}/install`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+  } catch (err) {
+    console.error('plugin service error', err);
+  }
+  res.status(201).json({ ok: true });
+});
+
+app.delete('/api/plugins/:name', async (req, res) => {
+  const tenantId = req.header(TENANT_HEADER);
+  if (!tenantId) return res.status(401).json({ error: 'missing tenant' });
+  const item = await getItem<{ tenantId: string; plugins: string[] }>(
+    PLUGINS_TABLE,
+    { tenantId }
+  );
+  if (!item) return res.status(404).json({ error: 'not found' });
+  item.plugins = item.plugins.filter((p) => p !== req.params.name);
+  await putItem(PLUGINS_TABLE, item);
+  try {
+    await fetch(`${PLUGIN_SERVICE_URL}/remove`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: req.params.name }),
+    });
+  } catch (err) {
+    console.error('plugin service error', err);
+  }
   res.json({ ok: true });
 });
 

--- a/apps/portal/src/pages/plugins.tsx
+++ b/apps/portal/src/pages/plugins.tsx
@@ -7,6 +7,7 @@ export default function Plugins() {
   const { data, mutate } = useSWR('/marketplace/plugins', fetcher);
   const [name, setName] = useState('');
   const [desc, setDesc] = useState('');
+  const [ratings, setRatings] = useState<Record<string, number>>({});
 
   const add = async () => {
     await fetch('/marketplace/plugins', {
@@ -17,6 +18,29 @@ export default function Plugins() {
     setName('');
     setDesc('');
     mutate();
+  };
+
+  const install = async (plugin: string) => {
+    await fetch('/api/plugins', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: plugin }),
+    });
+    alert('installed');
+  };
+
+  const remove = async (plugin: string) => {
+    await fetch(`/api/plugins/${plugin}`, { method: 'DELETE' });
+    alert('removed');
+  };
+
+  const rate = async (plugin: string) => {
+    await fetch('/plugins/rate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: plugin, value: ratings[plugin] || 0 }),
+    });
+    alert('rated');
   };
 
   return (
@@ -37,7 +61,19 @@ export default function Plugins() {
         {data &&
           data.map((p: any, i: number) => (
             <li key={i}>
-              {p.name} - {p.description}
+              {p.name} - {p.description}{' '}
+              <button onClick={() => install(p.name)}>Install</button>{' '}
+              <button onClick={() => remove(p.name)}>Remove</button>{' '}
+              <input
+                type="number"
+                min="1"
+                max="5"
+                value={ratings[p.name] || ''}
+                onChange={(e) =>
+                  setRatings({ ...ratings, [p.name]: Number(e.target.value) })
+                }
+              />
+              <button onClick={() => rate(p.name)}>Rate</button>
             </li>
           ))}
       </ul>

--- a/docs/plugin-marketplace.md
+++ b/docs/plugin-marketplace.md
@@ -1,3 +1,16 @@
 # Plugin Marketplace
 
 A central catalog for sharing and rating plugins built with `@iac/plugins`. Users can browse available modules and install them via the portal interface.
+
+## Submitting a Plugin
+
+1. Develop your module using the `@iac/plugins` package.
+2. Submit it to the marketplace with:
+
+```bash
+curl -X POST http://localhost:3005/plugins \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"my-plugin","description":"Adds auth"}'
+```
+
+3. The plugin will appear on the `/plugins` page where others can install and rate it.

--- a/services/plugins/README.md
+++ b/services/plugins/README.md
@@ -1,0 +1,12 @@
+# Plugins Service
+
+Stores installation counts and user ratings for marketplace plugins.
+
+## Endpoints
+
+- `POST /install` – record that a plugin was installed
+- `POST /remove` – record that a plugin was removed
+- `POST /rate` – submit a numeric rating for a plugin
+- `GET /stats` – fetch install and rating statistics
+
+Run with `node dist/index.js` after building.

--- a/services/plugins/package.json
+++ b/services/plugins/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@iac/plugins-service",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/plugins/src/index.test.ts
+++ b/services/plugins/src/index.test.ts
@@ -1,0 +1,11 @@
+import request from 'supertest';
+import { app } from './index';
+
+test('records installs and ratings', async () => {
+  await request(app).post('/install').send({ name: 'auth' });
+  await request(app).post('/rate').send({ name: 'auth', value: 5 });
+  const res = await request(app).get('/stats');
+  expect(res.body[0].name).toBe('auth');
+  expect(res.body[0].installs).toBe(1);
+  expect(res.body[0].ratings[0]).toBe(5);
+});

--- a/services/plugins/src/index.ts
+++ b/services/plugins/src/index.ts
@@ -1,0 +1,73 @@
+import express from 'express';
+import fs from 'fs';
+import { logAudit } from '../../packages/shared/src/audit';
+
+export const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  logAudit(`plugins ${req.method} ${req.url}`);
+  next();
+});
+
+const DB = process.env.PLUGINS_DB || '.plugin-meta.json';
+
+interface PluginMeta {
+  name: string;
+  installs: number;
+  ratings: number[];
+}
+
+function read(): PluginMeta[] {
+  if (!fs.existsSync(DB)) return [];
+  return JSON.parse(fs.readFileSync(DB, 'utf-8'));
+}
+
+function save(list: PluginMeta[]) {
+  fs.writeFileSync(DB, JSON.stringify(list, null, 2));
+}
+
+function find(name: string, list: PluginMeta[]) {
+  let p = list.find((pl) => pl.name === name);
+  if (!p) {
+    p = { name, installs: 0, ratings: [] };
+    list.push(p);
+  }
+  return p;
+}
+
+app.post('/install', (req, res) => {
+  const list = read();
+  const p = find(req.body.name, list);
+  p.installs++;
+  save(list);
+  res.status(201).json({ ok: true });
+});
+
+app.post('/remove', (req, res) => {
+  const list = read();
+  const p = find(req.body.name, list);
+  if (p.installs > 0) p.installs--;
+  save(list);
+  res.json({ ok: true });
+});
+
+app.post('/rate', (req, res) => {
+  const { name, value } = req.body;
+  const list = read();
+  const p = find(name, list);
+  p.ratings.push(Number(value));
+  save(list);
+  res.status(201).json({ ok: true });
+});
+
+app.get('/stats', (_req, res) => {
+  res.json(read());
+});
+
+export function start(port = 3006) {
+  app.listen(port, () => console.log(`plugins service listening on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3006);
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -160,6 +160,7 @@ This file records brief summaries of each pull request.
 - Updated task tracker to mark items 132 through 140 as completed.
 
 ## PR <pending> - Multi-language templates and analytics updates
+
 - Added FastAPI, Go and mobile codegen templates and selection in the orchestrator and portal.
 - Replaced connector stubs with functional Stripe and Slack API calls and added TensorFlow.js helper.
 - Implemented A/B testing endpoints in the analytics service with file persistence and tests.
@@ -176,6 +177,14 @@ This file records brief summaries of each pull request.
   and compliance enforcement.
 
 ## PR <pending> - Data connectors API integration
+
 - Added `/api/connectors` GET, POST and DELETE routes in the orchestrator with DynamoDB persistence.
 - Portal connectors page now loads and saves connector keys via the API.
 - Documented available connectors and API usage in `edge-connectors.md`.
+
+## PR <pending> - Plugin installation flow
+
+- Created plugins service to store install counts and ratings.
+- Added `/api/plugins` install and remove endpoints in the orchestrator and included plugins when dispatching jobs.
+- Portal marketplace page now provides install buttons and rating inputs.
+- Documented the plugin submission process in `plugin-marketplace.md`.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -136,9 +136,10 @@
 | 132    | Figma-to-Code Import Pipeline           | Completed |
 | 133    | AI-Based Test Generation                | Completed |
 | 134    | Visual Database Schema Designer         | Completed |
-| 135    | Voice-Guided Data Modeling             | Completed |
+| 135    | Voice-Guided Data Modeling              | Completed |
 | 136    | Edge Inference & Data Connectors        | Completed |
 | 137    | A/B Testing Toolkit                     | Completed |
 | 138    | VR Preview Enhancements                 | Completed |
 | 139    | GraphQL Builder & Template Marketplace  | Completed |
 | 140    | Regional Data Compliance Toolkit        | Completed |
+| 147    | Plugin Marketplace Installation Flow    | Completed |


### PR DESCRIPTION
## Summary
- track plugin installs and ratings in a new `plugins` service
- expose `/api/plugins` install/remove endpoints from orchestrator
- send installed plugins to codegen jobs
- add install and rating options to the portal marketplace page
- document how to submit plugins and mark task 147 complete

## Testing
- `npx prettier --write services/plugins/src/index.ts apps/orchestrator/src/index.ts apps/orchestrator/src/index.test.ts apps/portal/src/pages/plugins.tsx docs/plugin-marketplace.md services/plugins/src/index.test.ts steps_summary.md tasks_status.md services/plugins/README.md services/plugins/package.json`
- `npx turbo run test` *(fails: Need to install turbo)*

------
https://chatgpt.com/codex/tasks/task_e_686c39262fd483319958a76b424925a3