### PR TITLE
Add business tips analytics route

### DIFF
--- a/apps/portal/src/pages/dashboard.tsx
+++ b/apps/portal/src/pages/dashboard.tsx
@@ -7,6 +7,7 @@ const fetcher = (u: string) => fetch(u).then(r => r.json());
 export default function Dashboard() {
   const chartRef = useRef<HTMLCanvasElement>(null);
   const { data } = useSWR('/analytics/summary', fetcher);
+  const { data: tips } = useSWR('/analytics/businessTips', fetcher);
 
   useEffect(() => {
     if (!data || !chartRef.current) return;
@@ -32,6 +33,16 @@ export default function Dashboard() {
       <h1>Analytics Dashboard</h1>
       {!data && <p>Loading...</p>}
       <canvas ref={chartRef} height={200}></canvas>
+      {tips && (
+        <div style={{ marginTop: 20 }}>
+          <h2>Business Tips</h2>
+          <ul>
+            {tips.tips.map((t: string, i: number) => (
+              <li key={i}>{t}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/recommendation-engine.md
+++ b/docs/recommendation-engine.md
@@ -3,3 +3,12 @@
 This component analyzes usage data from the analytics service and suggests additional features for generated apps.
 
 Data is aggregated in DynamoDB and processed periodically to compute recommendations which are then exposed via a new API endpoint `/api/recommendations`.
+
+## Enabling Business Recommendations
+
+The analytics service provides a `/businessTips` endpoint that examines usage patterns
+and user ratings to suggest monetization strategies. To display these tips in the portal:
+
+1. Run the analytics service so that events are recorded.
+2. Ensure the portal can reach the service under the `/analytics` path.
+3. Open the **Dashboard** page to view a new **Business Tips** section with suggestions.

--- a/services/analytics/src/index.test.ts
+++ b/services/analytics/src/index.test.ts
@@ -15,3 +15,9 @@ test('create and fetch experiment', async () => {
   expect(res.status).toBe(200);
   expect(res.body.variant).toBe('A');
 });
+
+test('business tips endpoint returns tips', async () => {
+  const res = await request(app).get('/businessTips');
+  expect(res.status).toBe(200);
+  expect(Array.isArray(res.body.tips)).toBe(true);
+});

--- a/services/analytics/src/index.ts
+++ b/services/analytics/src/index.ts
@@ -104,6 +104,30 @@ app.get('/recommendations', (_req, res) => {
   res.json({ recommendations: generateRecommendations(events) });
 });
 
+function generateBusinessTips(events: any[]): string[] {
+  const tips: string[] = [];
+  const usageCount = events.length;
+  const ratings = events.filter((e) => e.type === 'rating');
+  const avgRating =
+    ratings.reduce((a, r) => a + Number(r.value || 0), 0) /
+    (ratings.length || 1);
+
+  if (usageCount > 100) {
+    tips.push('Consider tiered pricing for heavy usage.');
+  }
+  if (avgRating > 4) {
+    tips.push('Users are satisfied. Promote premium templates.');
+  }
+
+  if (tips.length === 0) tips.push('No business tips available.');
+  return tips;
+}
+
+app.get('/businessTips', (_req, res) => {
+  const events = readEvents();
+  res.json({ tips: generateBusinessTips(events) });
+});
+
 app.get('/complianceReport', (req, res) => {
   const policy = (req as any).policy as any;
   const events = readEvents();

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -239,3 +239,9 @@ This file records brief summaries of each pull request.
 - Added `/api/exportData` endpoints for region-aware export and deletion.
 - Analytics service now generates a compliance report.
 - Documented workflow in `docs/regional-compliance.md` and updated task status.
+
+## PR <pending> - Business tips analytics integration
+
+- Added `/businessTips` endpoint in the analytics service to suggest monetization strategies.
+- Dashboard page now fetches and displays these tips.
+- Documented enabling business recommendations in `docs/recommendation-engine.md`.


### PR DESCRIPTION
## Summary
- add `/businessTips` endpoint in the analytics service
- show monetization tips in the dashboard
- document how to enable business recommendations
- note changes in steps summary

## Testing
- `pnpm test --filter ./services/analytics` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c736d3db48331924811c35a2c4b2b