### PR TITLE
Add kafka/kinesis connectors and credential storage

### DIFF
--- a/apps/orchestrator/src/index.test.ts
+++ b/apps/orchestrator/src/index.test.ts
@@ -108,11 +108,26 @@ test('connectors API stores and retrieves config', async () => {
   expect(res.body.slackKey).toBe('sl');
 });
 
+test('connectors API stores credentials', async () => {
+  await request(app)
+    .post('/api/connectors')
+    .set('x-tenant-id', 't1')
+    .send({ credentials: { kafka: { username: 'u', password: 'p' } } });
+  const res = await request(app)
+    .get('/api/connectors')
+    .set('x-tenant-id', 't1');
+  expect(res.body.credentials.kafka.username).toBe('u');
+});
+
 test('connectors DELETE removes type', async () => {
   await request(app)
     .post('/api/connectors')
     .set('x-tenant-id', 't1')
-    .send({ stripeKey: 'sk', slackKey: 'sl' });
+    .send({
+      stripeKey: 'sk',
+      slackKey: 'sl',
+      credentials: { stripe: { secret: 's' } },
+    });
   await request(app)
     .delete('/api/connectors/stripe')
     .set('x-tenant-id', 't1');
@@ -120,6 +135,7 @@ test('connectors DELETE removes type', async () => {
     .get('/api/connectors')
     .set('x-tenant-id', 't1');
   expect(res.body.stripeKey).toBeUndefined();
+  expect(res.body.credentials.stripe).toBeUndefined();
   expect(res.body.slackKey).toBe('sl');
 });
 

--- a/docs/edge-connectors.md
+++ b/docs/edge-connectors.md
@@ -6,6 +6,8 @@ Connectors for services like Stripe and Slack can be configured in the portal un
 
 - **stripe** – provide `stripeKey` from your account
 - **slack** – provide a bot `slackKey`
+- **kafka** – specify `brokers`, `topic` and optional SASL credentials
+- **kinesis** – specify `streamName` and AWS credentials
 
 Keys are managed via the `/api/connectors` endpoints:
 
@@ -15,3 +17,35 @@ Keys are managed via the `/api/connectors` endpoints:
 
 This also enables optional TensorFlow.js models to run predictions in the browser for offline support.
 Use `/api/predict` to test models through the portal's connectors page.
+
+### Kafka Example
+
+```ts
+import { produceKafka, consumeKafka } from '@iac/data-connectors';
+
+await produceKafka(
+  { brokers: ['localhost:9092'], topic: 'demo' },
+  'hello world'
+);
+
+consumeKafka(
+  { brokers: ['localhost:9092'], topic: 'demo' },
+  async (msg) => console.log(msg)
+);
+```
+
+### Kinesis Setup
+
+```ts
+import { putKinesis, consumeKinesis } from '@iac/data-connectors';
+
+await putKinesis(
+  { streamName: 'demo', region: 'us-east-1' },
+  'hello'
+);
+
+consumeKinesis(
+  { streamName: 'demo', region: 'us-east-1' },
+  async (data) => console.log(data)
+);
+```

--- a/packages/data-connectors/README.md
+++ b/packages/data-connectors/README.md
@@ -1,6 +1,6 @@
 # Data Connectors
 
-Example connectors that third-party services can implement. This package currently includes functional Stripe and Slack connectors using their HTTP APIs.
+Example connectors that third-party services can implement. This package currently includes functional Stripe and Slack connectors using their HTTP APIs and helpers for Kafka and Amazon Kinesis streams.
 
 TensorFlow.js models can be placed under `model/` and loaded in the browser with `tfHelper.ts` for client-side inference.
 Prediction helpers are also exported for server-side endpoints.

--- a/packages/data-connectors/package.json
+++ b/packages/data-connectors/package.json
@@ -2,5 +2,9 @@
   "name": "@iac/data-connectors",
   "version": "0.1.0",
   "main": "src/index.ts",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@aws-sdk/client-kinesis": "^3.599.0",
+    "kafkajs": "^2.2.4"
+  }
 }

--- a/packages/data-connectors/src/index.ts
+++ b/packages/data-connectors/src/index.ts
@@ -6,6 +6,8 @@ export type Connector = (config: ConnectorConfig) => Promise<void>;
 
 import fetch from 'node-fetch';
 export * from './tfHelper';
+export * from './kafka';
+export * from './kinesis';
 
 export async function stripeConnector(config: ConnectorConfig) {
   const res = await fetch('https://api.stripe.com/v1/charges', {

--- a/packages/data-connectors/src/kafka.ts
+++ b/packages/data-connectors/src/kafka.ts
@@ -1,0 +1,44 @@
+import { Kafka, logLevel, SASLOptions } from 'kafkajs';
+
+export interface KafkaOptions {
+  brokers: string[];
+  topic: string;
+  ssl?: boolean;
+  sasl?: SASLOptions;
+}
+
+export async function produceKafka(
+  opts: KafkaOptions,
+  message: string
+): Promise<void> {
+  const kafka = new Kafka({
+    brokers: opts.brokers,
+    ssl: opts.ssl,
+    sasl: opts.sasl,
+    logLevel: logLevel.NOTHING,
+  });
+  const producer = kafka.producer();
+  await producer.connect();
+  await producer.send({ topic: opts.topic, messages: [{ value: message }] });
+  await producer.disconnect();
+}
+
+export async function consumeKafka(
+  opts: KafkaOptions,
+  onMessage: (msg: string) => Promise<void>
+): Promise<void> {
+  const kafka = new Kafka({
+    brokers: opts.brokers,
+    ssl: opts.ssl,
+    sasl: opts.sasl,
+    logLevel: logLevel.NOTHING,
+  });
+  const consumer = kafka.consumer({ groupId: 'iac-group' });
+  await consumer.connect();
+  await consumer.subscribe({ topic: opts.topic, fromBeginning: true });
+  await consumer.run({
+    eachMessage: async ({ message }) => {
+      if (message.value) await onMessage(message.value.toString());
+    },
+  });
+}

--- a/packages/data-connectors/src/kinesis.ts
+++ b/packages/data-connectors/src/kinesis.ts
@@ -1,0 +1,60 @@
+import {
+  KinesisClient,
+  PutRecordCommand,
+  ListShardsCommand,
+  GetShardIteratorCommand,
+  GetRecordsCommand,
+} from '@aws-sdk/client-kinesis';
+
+export interface KinesisOptions {
+  streamName: string;
+  region?: string;
+  credentials?: { accessKeyId: string; secretAccessKey: string };
+}
+
+export async function putKinesis(
+  opts: KinesisOptions,
+  data: string
+): Promise<void> {
+  const client = new KinesisClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+  await client.send(
+    new PutRecordCommand({
+      StreamName: opts.streamName,
+      PartitionKey: 'partition',
+      Data: Buffer.from(data),
+    })
+  );
+}
+
+export async function consumeKinesis(
+  opts: KinesisOptions,
+  onRecord: (data: string) => Promise<void>
+): Promise<void> {
+  const client = new KinesisClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+  const { Shards } = await client.send(
+    new ListShardsCommand({ StreamName: opts.streamName })
+  );
+  if (!Shards || Shards.length === 0) return;
+  const shardId = Shards[0].ShardId as string;
+  const { ShardIterator } = await client.send(
+    new GetShardIteratorCommand({
+      StreamName: opts.streamName,
+      ShardId: shardId,
+      ShardIteratorType: 'LATEST',
+    })
+  );
+  if (!ShardIterator) return;
+  const { Records } = await client.send(
+    new GetRecordsCommand({ ShardIterator })
+  );
+  for (const record of Records || []) {
+    const dataStr = Buffer.from(record.Data as Uint8Array).toString();
+    await onRecord(dataStr);
+  }
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -239,3 +239,11 @@ This file records brief summaries of each pull request.
 - Added `/api/exportData` endpoints for region-aware export and deletion.
 - Analytics service now generates a compliance report.
 - Documented workflow in `docs/regional-compliance.md` and updated task status.
+
+## PR <pending> - Messaging connector helpers
+
+- Added `kafka.ts` and `kinesis.ts` in `@iac/data-connectors` with simple produce
+  and consume helpers.
+- Extended orchestrator connector routes to persist credentials alongside config
+  in `CONNECTORS_TABLE`.
+- Documented Kafka and Kinesis examples in `docs/edge-connectors.md`.


### PR DESCRIPTION
## Summary
- add Kafka and Kinesis helpers under `@iac/data-connectors`
- extend orchestrator connector routes to persist credentials
- document messaging connectors in `edge-connectors.md`
- mention new connectors in package readme
- record summary of changes

## Testing
- `pnpm install` *(fails: `react-flow-renderer` version not found)*
- `npm install` *(fails: dependency conflict)*
- `npm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c737428d48331a5a20726aa908c8f