### PR TITLE
Add collaborative editing via WebSockets

### DIFF
--- a/apps/portal/src/README.md
+++ b/apps/portal/src/README.md
@@ -25,3 +25,7 @@ Additional pages:
 - `tutorial-builder.tsx` – compose in-app guides
 - `ethics-dashboard.tsx` – transparency metrics overview
 - Translations loaded via `packages/i18n` when `localStorage.lang` is set.
+
+## Collaborative Editing
+
+Run the collab service and open multiple browser windows on `create.tsx` to edit the description together. Changes and cursor positions are synced over WebSockets at `ws://localhost:4000`.

--- a/apps/portal/src/components/CollabEditor.tsx
+++ b/apps/portal/src/components/CollabEditor.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export default function CollabEditor({ value, onChange }: Props) {
+  const [cursors, setCursors] = useState<Record<string, number>>({});
+  const wsRef = useRef<WebSocket>();
+  const userId = useRef(`u-${Math.random().toString(36).slice(2, 8)}`);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:4000');
+    wsRef.current = ws;
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: 'join', userId: userId.current }));
+    };
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        if (msg.type === 'update') {
+          onChange(msg.data);
+        } else if (msg.type === 'cursors') {
+          setCursors(msg.data);
+        } else if (msg.type === 'init') {
+          onChange(msg.data);
+          setCursors(msg.cursors || {});
+        }
+      } catch {
+        // ignore
+      }
+    };
+    return () => ws.close();
+  }, [onChange]);
+
+  const sendUpdate = (text: string) => {
+    onChange(text);
+    const pos = textareaRef.current?.selectionStart || 0;
+    wsRef.current?.send(
+      JSON.stringify({
+        type: 'update',
+        data: text,
+        cursor: pos,
+      })
+    );
+  };
+
+  const sendCursor = () => {
+    const pos = textareaRef.current?.selectionStart || 0;
+    wsRef.current?.send(
+      JSON.stringify({ type: 'cursor', cursor: pos })
+    );
+  };
+
+  return (
+    <div>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => sendUpdate(e.target.value)}
+        onKeyUp={sendCursor}
+        onClick={sendCursor}
+        style={{ width: '100%', minHeight: 120 }}
+      />
+      <div style={{ fontSize: 12, marginTop: 4 }}>
+        Active cursors:
+        {Object.entries(cursors).map(([u, p]) => (
+          <span key={u} style={{ marginLeft: 8 }}>
+            {u}@{p}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/src/pages/create.tsx
+++ b/apps/portal/src/pages/create.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react';
+import CollabEditor from '../components/CollabEditor';
 
 export default function CreateApp() {
   const [description, setDescription] = useState('');
@@ -45,10 +46,7 @@ export default function CreateApp() {
     <div>
       <form onSubmit={handleSubmit}>
         <h1>New App</h1>
-        <textarea
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-        />
+        <CollabEditor value={description} onChange={setDescription} />
         <div>
           <label>
             Language

--- a/services/collab/README.md
+++ b/services/collab/README.md
@@ -1,0 +1,12 @@
+# Collaboration Service
+
+WebSocket backend for real-time description editing.
+
+## Usage
+
+```
+pnpm --filter collab-service build
+node services/collab/dist/index.js
+```
+
+Connect clients to `ws://localhost:4000`.

--- a/services/collab/package.json
+++ b/services/collab/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "collab-service",
+  "version": "0.1.0",
+  "dependencies": {
+    "ws": "^8.18.3"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  }
+}

--- a/services/collab/src/index.ts
+++ b/services/collab/src/index.ts
@@ -1,0 +1,81 @@
+import { WebSocketServer, WebSocket } from 'ws';
+
+const DEFAULT_PORT = Number(process.env.PORT || 4000);
+
+let wss: WebSocketServer | undefined;
+let content = '';
+const cursors = new Map<string, number>();
+
+function broadcast(data: any) {
+  if (!wss) return;
+  const msg = JSON.stringify(data);
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(msg);
+    }
+  }
+}
+
+function broadcastCursors() {
+  broadcast({ type: 'cursors', data: Object.fromEntries(cursors) });
+}
+
+function setup(server: WebSocketServer) {
+  server.on('connection', (ws) => {
+    let userId = `user-${Math.random().toString(36).slice(2, 8)}`;
+
+    ws.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw.toString());
+        switch (msg.type) {
+          case 'join':
+            userId = msg.userId || userId;
+            cursors.set(userId, 0);
+            broadcastCursors();
+            break;
+          case 'init':
+            content = msg.data;
+            broadcast({ type: 'update', data: content });
+            break;
+          case 'update':
+            content = msg.data;
+            if (typeof msg.cursor === 'number') {
+              cursors.set(userId, msg.cursor);
+              broadcastCursors();
+            }
+            broadcast({ type: 'update', data: content });
+            break;
+          case 'cursor':
+            cursors.set(userId, msg.cursor);
+            broadcastCursors();
+            break;
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    ws.on('close', () => {
+      cursors.delete(userId);
+      broadcastCursors();
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: 'init',
+        data: content,
+        cursors: Object.fromEntries(cursors),
+      })
+    );
+  });
+}
+
+export function start(port = DEFAULT_PORT) {
+  wss = new WebSocketServer({ port });
+  setup(wss);
+  console.log(`collab service listening on ${port}`);
+}
+
+if (require.main === module) {
+  start();
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -239,3 +239,9 @@ This file records brief summaries of each pull request.
 - Added `/api/exportData` endpoints for region-aware export and deletion.
 - Analytics service now generates a compliance report.
 - Documented workflow in `docs/regional-compliance.md` and updated task status.
+
+## PR <pending> - Collaborative description editing
+
+- Added `collab-service` WebSocket backend for shared editing.
+- Created `CollabEditor` component and integrated it on the create page.
+- Portal README explains how to use the collaborative editor.


### PR DESCRIPTION
## Summary
- create `collab-service` with WebSocket backend for shared description editing
- add `CollabEditor` React component
- integrate collaborative editor on the create page
- document collaboration feature in portal README
- record summary in `steps_summary.md`

## Testing
- `pnpm install` *(fails: `ERR_PNPM_NO_MATCHING_VERSION`)*

------
https://chatgpt.com/codex/tasks/task_e_686c73922f988331a753c9af148d723c