### PR TITLE
Add billing service and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository uses a monorepo structure as outlined in `implementation_plan.md
 - **services/email** – SES email wrapper
 - **services/analytics** – collect usage metrics
 - **services/marketplace** – community plugin catalog
+- **services/billing** – subscription management
 
 ## Getting Started
 

--- a/apps/portal/src/README.md
+++ b/apps/portal/src/README.md
@@ -19,6 +19,7 @@ Additional pages:
 - `apps.tsx` – list all generated apps and their current status.
 - `account.tsx` – update email or password.
 - `dashboard.tsx` – show analytics summaries.
+- `billing.tsx` – manage plans and view subscriber metrics.
 - `logs.tsx` – view build logs.
 - Google Analytics is loaded when `NEXT_PUBLIC_GA_ID` is set.
 - `vr-preview.tsx` – inspect generated interfaces in WebXR

--- a/apps/portal/src/pages/billing.tsx
+++ b/apps/portal/src/pages/billing.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import useSWR from 'swr';
+
+const fetcher = (u: string) => fetch(u).then(r => r.json());
+
+export default function Billing() {
+  const { data: plans, mutate } = useSWR('/billing/plans', fetcher);
+  const { data: metrics } = useSWR('/billing/metrics', fetcher);
+  const [id, setId] = useState('');
+  const [price, setPrice] = useState('');
+
+  const add = async () => {
+    await fetch('/billing/plans', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, price: Number(price) }),
+    });
+    setId('');
+    setPrice('');
+    mutate();
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Billing</h1>
+      <div>
+        <input placeholder="Plan id" value={id} onChange={e => setId(e.target.value)} />
+        <input placeholder="Price" value={price} onChange={e => setPrice(e.target.value)} />
+        <button onClick={add}>Save</button>
+      </div>
+      <h2>Plans</h2>
+      <ul>
+        {plans && plans.map((p: any) => (
+          <li key={p.id}>{p.id} - ${p.price}</li>
+        ))}
+      </ul>
+      <h2>Subscribers</h2>
+      <pre>{JSON.stringify(metrics, null, 2)}</pre>
+    </div>
+  );
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,4 @@ This folder contains user guides and architecture diagrams.
 - [Regional Compliance](./regional-compliance.md)
 - [Localization](./i18n.md)
 - [Dashboard Monitoring](./dashboard-monitoring.md)
+- [Billing Toolkit](./billing-toolkit.md)

--- a/docs/billing-toolkit.md
+++ b/docs/billing-toolkit.md
@@ -1,0 +1,13 @@
+# Billing Toolkit
+
+The billing service exposes simple endpoints for managing subscription plans and subscribers.
+
+## Endpoints
+
+- `GET /billing/plans` – list configured plans
+- `POST /billing/plans` – create or update a plan
+- `POST /billing/subscribe` – subscribe a user to a plan
+- `GET /billing/metrics` – subscriber counts per plan
+- `POST /billing/webhook` – Stripe webhook receiver
+
+Use these endpoints from your generated apps to enable paid tiers. When running locally, the service stores data in `.billing.json`.

--- a/packages/codegen-templates/src/templates/billing/README.md
+++ b/packages/codegen-templates/src/templates/billing/README.md
@@ -1,0 +1,3 @@
+# Billing Template
+
+Scaffolds subscription management with basic Stripe integration.

--- a/packages/codegen-templates/src/templates/billing/subscription.ts
+++ b/packages/codegen-templates/src/templates/billing/subscription.ts
@@ -1,0 +1,20 @@
+import Stripe from 'stripe';
+import express from 'express';
+
+export function createBillingRouter() {
+  const router = express.Router();
+  const stripe = new Stripe('sk-test', { apiVersion: '2020-08-27' });
+
+  router.post('/subscribe', async (req, res) => {
+    const { customer, price } = req.body;
+    await stripe.subscriptions.create({ customer, items: [{ price }] });
+    res.json({ ok: true });
+  });
+
+  router.post('/webhook', (req, res) => {
+    // handle webhook events
+    res.json({ received: true });
+  });
+
+  return router;
+}

--- a/packages/codegen-templates/src/templates/index.ts
+++ b/packages/codegen-templates/src/templates/index.ts
@@ -7,4 +7,5 @@ export const templates = [
   { name: 'fastapi', description: 'Python FastAPI boilerplate' },
   { name: 'go', description: 'Go REST API boilerplate' },
   { name: 'mobile', description: 'React Native starter app' },
+  { name: 'billing', description: 'Subscription billing with Stripe' },
 ];

--- a/services/billing/README.md
+++ b/services/billing/README.md
@@ -1,0 +1,13 @@
+# Billing Service
+
+Handles subscription plans and Stripe webhooks.
+
+## Endpoints
+
+- `GET /plans` – list available plans
+- `POST /plans` – create or update a subscription plan
+- `POST /subscribe` – subscribe a user to a plan
+- `GET /metrics` – current subscriber counts
+- `POST /webhook` – receive events from Stripe
+
+Run with `node dist/index.js` after building.

--- a/services/billing/package.json
+++ b/services/billing/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "billing-service",
+  "version": "0.1.0",
+  "dependencies": {
+    "express": "^4.18.2",
+    "stripe": "^12.5.0"
+  },
+  "scripts": {
+    "build": "echo building billing-service",
+    "lint": "echo linting billing-service",
+    "test": "jest"
+  }
+}

--- a/services/billing/src/index.ts
+++ b/services/billing/src/index.ts
@@ -1,0 +1,79 @@
+import express from 'express';
+import fs from 'fs';
+import Stripe from 'stripe';
+import { logAudit } from '../../packages/shared/src/audit';
+import { policyMiddleware } from '../../packages/shared/src/policyMiddleware';
+
+export const app = express();
+app.use(express.json());
+app.use(policyMiddleware);
+app.use((req, _res, next) => {
+  logAudit(`billing ${req.method} ${req.url}`);
+  next();
+});
+
+const DB = process.env.BILLING_DB || '.billing.json';
+const stripe = new Stripe('sk-test', { apiVersion: '2020-08-27' });
+
+interface Plan {
+  id: string;
+  price: number;
+}
+
+interface Subscription {
+  user: string;
+  plan: string;
+}
+
+function read(): { plans: Plan[]; subs: Subscription[] } {
+  if (!fs.existsSync(DB)) return { plans: [], subs: [] };
+  return JSON.parse(fs.readFileSync(DB, 'utf-8'));
+}
+
+function save(data: { plans: Plan[]; subs: Subscription[] }) {
+  fs.writeFileSync(DB, JSON.stringify(data, null, 2));
+}
+
+app.get('/plans', (_req, res) => {
+  const data = read();
+  res.json(data.plans);
+});
+
+app.post('/plans', (req, res) => {
+  const data = read();
+  const idx = data.plans.findIndex((p) => p.id === req.body.id);
+  if (idx >= 0) data.plans[idx] = req.body;
+  else data.plans.push(req.body);
+  save(data);
+  res.status(201).json({ ok: true });
+});
+
+app.post('/subscribe', (req, res) => {
+  const data = read();
+  data.subs.push({ user: req.body.user, plan: req.body.plan });
+  save(data);
+  res.status(201).json({ ok: true });
+});
+
+app.get('/metrics', (_req, res) => {
+  const data = read();
+  const counts: Record<string, number> = {};
+  for (const s of data.subs) {
+    counts[s.plan] = (counts[s.plan] || 0) + 1;
+  }
+  res.json(counts);
+});
+
+app.post('/webhook', (req, res) => {
+  const event = req.body;
+  logAudit(`stripe event ${event.type}`);
+  res.json({ received: true });
+});
+
+export function start(port = 3007) {
+  app.listen(port, () => console.log(`billing listening on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3007);
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -239,3 +239,10 @@ This file records brief summaries of each pull request.
 - Added `/api/exportData` endpoints for region-aware export and deletion.
 - Analytics service now generates a compliance report.
 - Documented workflow in `docs/regional-compliance.md` and updated task status.
+
+## PR <pending> - Billing service and templates
+
+- Added `services/billing` exposing plan, subscribe and webhook endpoints with metrics.
+- New `billing` code generation template scaffolds Stripe subscription logic.
+- Portal now includes a Billing settings page for managing plans and viewing subscribers.
+- Documented API usage in `docs/billing-toolkit.md` and linked from docs README.


### PR DESCRIPTION
## Summary
- introduce `services/billing` to manage subscription plans
- expose billing endpoints in REST API
- add `billing` codegen template for Stripe subscriptions
- show subscriber metrics in new portal Billing page
- document billing API usage and link from docs README

## Testing
- `npx turbo run test` *(fails: needs turbo download)*

------
https://chatgpt.com/codex/tasks/task_e_686c73bace288331b22bf629da978d9c