### PR TITLE
Add collaborative workflow service and sync

### DIFF
--- a/apps/portal/src/pages/workflow.tsx
+++ b/apps/portal/src/pages/workflow.tsx
@@ -1,14 +1,40 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import ReactFlow, { MiniMap, Controls, Background } from 'react-flow-renderer';
 
 export default function Workflow() {
   const [elements, setElements] = useState<any[]>([]);
+  const wsRef = useRef<WebSocket | null>(null);
+  const fromRemote = useRef(false);
 
   useEffect(() => {
     fetch('/api/workflow')
       .then((r) => r.json())
       .then((d) => setElements(d.nodes || []));
+    const url = process.env.NEXT_PUBLIC_COLLAB_SERVER || 'ws://localhost:4001';
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+    ws.onmessage = (evt) => {
+      try {
+        const { type, data } = JSON.parse(evt.data);
+        if (type === 'init') {
+          fromRemote.current = true;
+          setElements(data.nodes || []);
+        } else if (type === 'update') {
+          fromRemote.current = true;
+          setElements(data);
+        }
+      } catch {}
+    };
+    return () => ws.close();
   }, []);
+
+  useEffect(() => {
+    if (!wsRef.current || fromRemote.current) {
+      fromRemote.current = false;
+      return;
+    }
+    wsRef.current.send(JSON.stringify({ type: 'update', data: elements }));
+  }, [elements]);
 
   const save = async () => {
     await fetch('/api/workflow', {

--- a/services/collab-workflow/README.md
+++ b/services/collab-workflow/README.md
@@ -1,0 +1,11 @@
+# Collaborative Workflow Service
+
+WebSocket server that broadcasts workflow builder updates to all connected clients and
+persists changes via the orchestrator.
+
+## Usage
+
+Set `ORCHESTRATOR_URL` to point to the orchestrator API. Run with `node dist/index.js` after building.
+
+Clients should send messages of the form `{ type: 'update', data: <workflow> }`.
+On connection, the server sends the current workflow using `{ type: 'init', data }`.

--- a/services/collab-workflow/package.json
+++ b/services/collab-workflow/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "collab-workflow-service",
+  "version": "0.1.0",
+  "dependencies": {
+    "ws": "^8.18.3",
+    "node-fetch": "^3.3.2"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "lint": "echo linting collab-workflow-service",
+    "test": "jest"
+  }
+}

--- a/services/collab-workflow/src/index.test.ts
+++ b/services/collab-workflow/src/index.test.ts
@@ -1,0 +1,23 @@
+import WebSocket from 'ws';
+import { start } from './index';
+
+test('broadcasts workflow updates', (done) => {
+  const wss = start(0);
+  const { port } = wss.address() as any;
+  const a = new WebSocket(`ws://localhost:${port}`);
+  const b = new WebSocket(`ws://localhost:${port}`);
+
+  b.on('message', (msg) => {
+    const { type, data } = JSON.parse(msg.toString());
+    if (type === 'update' && data.test === true) {
+      wss.close();
+      done();
+    }
+  });
+
+  b.on('open', () => {
+    a.on('open', () => {
+      a.send(JSON.stringify({ type: 'update', data: { test: true } }));
+    });
+  });
+});

--- a/services/collab-workflow/src/index.ts
+++ b/services/collab-workflow/src/index.ts
@@ -1,0 +1,48 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import fetch from 'node-fetch';
+import { initSentry } from '../../packages/shared/src/sentry';
+import { logAudit } from '../../packages/shared/src/audit';
+
+const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:3002';
+
+export function start(port = 4001) {
+  initSentry('collab-workflow');
+  const wss = new WebSocketServer({ port });
+  wss.on('connection', async (ws) => {
+    logAudit('collab-workflow connection');
+    try {
+      const res = await fetch(`${ORCHESTRATOR_URL}/api/workflow`);
+      const data = await res.json();
+      ws.send(JSON.stringify({ type: 'init', data }));
+    } catch (err) {
+      console.error('init fetch failed', err);
+    }
+    ws.on('message', async (msg) => {
+      try {
+        const { type, data } = JSON.parse(msg.toString());
+        if (type === 'update') {
+          for (const client of wss.clients) {
+            if (client !== ws && client.readyState === WebSocket.OPEN) {
+              client.send(JSON.stringify({ type: 'update', data }));
+            }
+          }
+          try {
+            await fetch(`${ORCHESTRATOR_URL}/api/workflow`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(data),
+            });
+          } catch (err) {
+            console.error('persist failed', err);
+          }
+        }
+      } catch {}
+    });
+  });
+  console.log(`collab-workflow listening on ${port}`);
+  return wss;
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 4001);
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -239,3 +239,8 @@ This file records brief summaries of each pull request.
 - Added `/api/exportData` endpoints for region-aware export and deletion.
 - Analytics service now generates a compliance report.
 - Documented workflow in `docs/regional-compliance.md` and updated task status.
+
+## PR <pending> - Collaborative workflow builder
+
+- Added `collab-workflow` service that uses WebSockets to broadcast workflow updates and persist them via the orchestrator API.
+- Workflow builder page now connects to the WebSocket server to sync edits in real time.


### PR DESCRIPTION
## Summary
- create `collab-workflow` service using WebSockets
- sync the portal workflow builder with the service
- persist updates via existing orchestrator endpoint
- document changes in steps summary

## Testing
- `npx jest` *(fails: Needs to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_686c741ee9b48331b57d34c448cceb95