### PR TITLE
Implement multi-cloud deployment templates

### DIFF
--- a/apps/orchestrator/src/README.md
+++ b/apps/orchestrator/src/README.md
@@ -11,14 +11,16 @@ node apps/orchestrator/src/index.ts
 ## Endpoints
 
 - `POST /api/createApp` – start a new code generation job. Body:
-  `{ "description": "my idea", "language": "node" }`. Returns a `jobId`.
+  `{ "description": "my idea", "language": "node", "provider": "aws" }`.
+  Returns a `jobId`.
 - `GET /api/status/:id` – retrieve the current status of a job.
 - `GET /api/apps` – list all generated apps.
 - `POST /api/redeploy/:id` – submit a new description to redeploy an existing app.
 
-Set `DEPLOY_URL` to the deployment webhook and `NOTIFY_EMAIL` to receive job
-notifications.
+Set `DEPLOY_URL`, `GCP_DEPLOY_URL` and `AZURE_DEPLOY_URL` to the deployment
+webhooks for each provider. `NOTIFY_EMAIL` enables job notifications.
 
 When `ARTIFACTS_BUCKET` is configured, generated code is uploaded to that S3 bucket after each job completes.
 
-Set `TENANTS_TABLE` to a DynamoDB table storing `{ id, provider }` for each tenant. Supported providers are `aws`, `azure` and `gcp`.
+Set `TENANTS_TABLE` to a DynamoDB table storing `{ id, provider }` for each tenant.
+Supported providers are `aws`, `azure` and `gcp`.

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -39,6 +39,8 @@ app.use((req, _res, next) => {
 const JOBS_TABLE = process.env.JOBS_TABLE || 'jobs';
 const CODEGEN_URL = process.env.CODEGEN_URL || 'http://localhost:3003/generate';
 const DEPLOY_URL = process.env.DEPLOY_URL;
+const GCP_DEPLOY_URL = process.env.GCP_DEPLOY_URL;
+const AZURE_DEPLOY_URL = process.env.AZURE_DEPLOY_URL;
 const NOTIFY_EMAIL = process.env.NOTIFY_EMAIL;
 const ARTIFACTS_BUCKET = process.env.ARTIFACTS_BUCKET;
 const TENANT_HEADER = 'x-tenant-id';
@@ -62,20 +64,24 @@ async function getProvider(tenantId: string): Promise<'aws' | 'azure' | 'gcp'> {
 export interface Job {
   id: string;
   tenantId: string;
-  provider: 'aws' | 'azure' | 'gcp';
+  provider: 'aws' | 'gcp' | 'azure';
   description: string;
   language: string;
   status: 'queued' | 'running' | 'complete' | 'failed';
   created: number;
 }
 
-async function triggerDeploy(jobId: string) {
-  if (!DEPLOY_URL) {
-    console.log('deploy url not configured, skipping deploy');
+async function triggerDeploy(jobId: string, provider: string) {
+  let url: string | undefined;
+  if (provider === 'aws') url = DEPLOY_URL;
+  if (provider === 'gcp') url = GCP_DEPLOY_URL;
+  if (provider === 'azure') url = AZURE_DEPLOY_URL;
+  if (!url) {
+    console.log('deploy url not configured for provider', provider);
     return;
   }
   try {
-    await fetch(DEPLOY_URL, {
+    await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ jobId }),
@@ -123,7 +129,7 @@ export async function dispatchJob(job: Job) {
       await uploadObject(ARTIFACTS_BUCKET, `${job.id}.txt`, code);
     }
     await putItem(JOBS_TABLE, { ...job, status: 'complete' });
-    await triggerDeploy(job.id);
+    await triggerDeploy(job.id, job.provider);
     if (NOTIFY_EMAIL) {
       sendEmail({
         template: 'job-complete',
@@ -148,15 +154,16 @@ configureHealing(dispatchJob);
 app.post('/api/createApp', async (req, res) => {
   const tenantId = req.header(TENANT_HEADER);
   if (!tenantId) return res.status(401).json({ error: 'missing tenant' });
-  const { description, language = 'node' } = req.body;
+  const { description, language = 'node', provider } = req.body;
   if (!description)
     return res.status(400).json({ error: 'missing description' });
   const id = randomUUID();
-  const provider = await getProvider(tenantId);
+  const prov: 'aws' | 'gcp' | 'azure' =
+    provider || (await getProvider(tenantId));
   const job: Job = {
     id,
     tenantId,
-    provider,
+    provider: prov,
     description,
     language,
     status: 'queued',
@@ -340,15 +347,16 @@ app.post('/api/predict', async (req, res) => {
 app.post('/api/redeploy/:id', async (req, res) => {
   const tenantId = req.header(TENANT_HEADER);
   if (!tenantId) return res.status(401).json({ error: 'missing tenant' });
-  const { description, language = 'node' } = req.body;
+  const { description, language = 'node', provider } = req.body;
   if (!description)
     return res.status(400).json({ error: 'missing description' });
   const id = req.params.id;
-  const provider = await getProvider(tenantId);
+  const prov: 'aws' | 'gcp' | 'azure' =
+    provider || (await getProvider(tenantId));
   const job: Job = {
     id,
     tenantId,
-    provider,
+    provider: prov,
     description,
     language,
     status: 'queued',

--- a/docs/multi-cloud.md
+++ b/docs/multi-cloud.md
@@ -1,0 +1,26 @@
+# Multi-Cloud Deployment
+
+Generated apps can be deployed to AWS, GCP or Azure. Terraform modules for each
+provider live under `infrastructure/<provider>`.
+
+## Modules
+- `infrastructure/gcp/networking` – VPC network and subnets
+- `infrastructure/gcp/iam` – service accounts and roles
+- `infrastructure/gcp/container-services` – GKE cluster
+- `infrastructure/azure/networking` – virtual network and subnets
+- `infrastructure/azure/iam` – service principals and role assignments
+- `infrastructure/azure/container-services` – AKS cluster
+
+Run `terraform init` in any module directory and supply provider credentials via
+Terraform variables or environment settings.
+
+## Portal Usage
+
+When creating an app you can now choose the target provider. The orchestrator
+stores this value on the job and triggers the matching deployment webhook.
+
+## Limitations
+
+- Only basic networking, IAM and container clusters are provisioned.
+- Cross‑cloud networking is not automated.
+- Deployment hooks must be implemented per provider.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,22 +1,27 @@
 # Infrastructure Modules
 
-This folder contains Terraform modules used to provision cloud resources for the platform. Modules under the root of `infrastructure/` target AWS. Two additional folders provide equivalent modules for Azure and GCP.
-
-```
-infrastructure/
-  azure/      # Azure implementations
-  gcp/        # Google Cloud implementations
-  <aws modules>
-```
+This folder contains Terraform modules used to provision cloud resources for the platform.
 
 ## Deployment
 
-Choose the folder that matches your cloud provider, then run Terraform as usual. For example to deploy on Azure:
+Run the following commands from this directory to deploy the infrastructure:
 
 ```bash
-cd infrastructure/azure/terraform
 terraform init
 terraform plan
 ```
 
-The module interfaces are kept consistent so switching providers only requires pointing Terraform at the desired directory.
+Apply the plan with `terraform apply` when you're ready to create or update resources.
+
+Each subfolder under `infrastructure/` represents a reusable module. Before
+running the commands above ensure your AWS credentials are configured and any
+required variables are set either via `terraform.tfvars` or environment
+variables.
+
+Example for the VPC module:
+
+```bash
+cd vpc
+terraform init
+terraform plan -var-file=example.tfvars
+```

--- a/infrastructure/azure/container-services/README.md
+++ b/infrastructure/azure/container-services/README.md
@@ -1,0 +1,16 @@
+# Azure Container Services Module
+
+Provisions an AKS cluster.
+
+## Usage
+```hcl
+module "aks" {
+  source         = "./infrastructure/azure/container-services"
+  cluster_name   = "demo-aks"
+  location       = "eastus"
+  resource_group = "my-rg"
+  node_count     = 1
+}
+```
+
+Initialize with `terraform init` and review with `terraform plan`.

--- a/infrastructure/azure/container-services/main.tf
+++ b/infrastructure/azure/container-services/main.tf
@@ -1,0 +1,13 @@
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = var.cluster_name
+  location            = var.location
+  resource_group_name = var.resource_group
+  default_node_pool {
+    name       = "default"
+    node_count = var.node_count
+    vm_size    = "Standard_B2s"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}

--- a/infrastructure/azure/container-services/outputs.tf
+++ b/infrastructure/azure/container-services/outputs.tf
@@ -1,0 +1,4 @@
+output "kube_config" {
+  description = "Kubeconfig of the cluster"
+  value       = azurerm_kubernetes_cluster.aks.kube_config_raw
+}

--- a/infrastructure/azure/container-services/variables.tf
+++ b/infrastructure/azure/container-services/variables.tf
@@ -1,0 +1,20 @@
+variable "cluster_name" {
+  description = "AKS cluster name"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure location"
+  type        = string
+}
+
+variable "resource_group" {
+  description = "Resource group name"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of nodes"
+  type        = number
+  default     = 1
+}

--- a/infrastructure/azure/iam/README.md
+++ b/infrastructure/azure/iam/README.md
@@ -1,15 +1,15 @@
-# Azure AD Roles Module
+# Azure IAM Module
 
-This Terraform module creates Azure AD roles with attached policies so services can operate with least privilege.
+Creates a service principal with role assignments.
 
 ## Usage
 ```hcl
-module "iam" {
-  source            = "./infrastructure/iam"
-  role_name         = "demo-role"
-  assume_role_service = "lambda.amazonaws.com"
-  policy_json       = file("./policy.json")
+module "azure_iam" {
+  source          = "./infrastructure/azure/iam"
+  app_name        = "demo-sp"
+  role_definition = "Contributor"
+  resource_group  = "my-rg"
 }
 ```
 
-Run `terraform init` and `terraform fmt` in this directory before applying.
+Run `terraform init` and `terraform plan` before applying.

--- a/infrastructure/azure/iam/main.tf
+++ b/infrastructure/azure/iam/main.tf
@@ -1,2 +1,17 @@
-# Placeholder module for azure iam. Replace with provider-specific resources.
-resource "null_resource" "placeholder" {}
+resource "azurerm_ad_app_registration" "app" {
+  display_name = var.app_name
+}
+
+resource "azurerm_ad_service_principal" "sp" {
+  application_id = azurerm_ad_app_registration.app.application_id
+}
+
+data "azurerm_resource_group" "rg" {
+  name = var.resource_group
+}
+
+resource "azurerm_role_assignment" "assign" {
+  scope                = data.azurerm_resource_group.rg.id
+  role_definition_name = var.role_definition
+  principal_id         = azurerm_ad_service_principal.sp.id
+}

--- a/infrastructure/azure/iam/outputs.tf
+++ b/infrastructure/azure/iam/outputs.tf
@@ -1,3 +1,4 @@
-output "id" {
-  value = null_resource.placeholder.id
+output "service_principal_id" {
+  description = "ID of the created service principal"
+  value       = azurerm_ad_service_principal.sp.id
 }

--- a/infrastructure/azure/iam/variables.tf
+++ b/infrastructure/azure/iam/variables.tf
@@ -1,14 +1,14 @@
-variable "role_name" {
-  description = "Name of the IAM role"
+variable "app_name" {
+  description = "Name for the app registration"
   type        = string
 }
 
-variable "assume_role_service" {
-  description = "Service that can assume this role"
+variable "role_definition" {
+  description = "Built-in role name"
   type        = string
 }
 
-variable "policy_json" {
-  description = "JSON policy document"
+variable "resource_group" {
+  description = "Resource group to scope the role to"
   type        = string
 }

--- a/infrastructure/azure/networking/README.md
+++ b/infrastructure/azure/networking/README.md
@@ -1,0 +1,17 @@
+# Azure Networking Module
+
+Creates a virtual network and subnets.
+
+## Usage
+```hcl
+module "az_network" {
+  source        = "./infrastructure/azure/networking"
+  vnet_name     = "demo-vnet"
+  address_space = ["10.20.0.0/16"]
+  subnet_cidrs  = ["10.20.1.0/24"]
+  location      = "eastus"
+  resource_group = "rg"
+}
+```
+
+Initialize with `terraform init` before applying.

--- a/infrastructure/azure/networking/main.tf
+++ b/infrastructure/azure/networking/main.tf
@@ -1,0 +1,14 @@
+resource "azurerm_virtual_network" "vnet" {
+  name                = var.vnet_name
+  address_space       = var.address_space
+  location            = var.location
+  resource_group_name = var.resource_group
+}
+
+resource "azurerm_subnet" "subnets" {
+  count               = length(var.subnet_cidrs)
+  name                = "${var.vnet_name}-subnet-${count.index}"
+  resource_group_name = var.resource_group
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes    = [var.subnet_cidrs[count.index]]
+}

--- a/infrastructure/azure/networking/outputs.tf
+++ b/infrastructure/azure/networking/outputs.tf
@@ -1,0 +1,4 @@
+output "vnet_id" {
+  description = "ID of the VNet"
+  value       = azurerm_virtual_network.vnet.id
+}

--- a/infrastructure/azure/networking/variables.tf
+++ b/infrastructure/azure/networking/variables.tf
@@ -1,0 +1,24 @@
+variable "vnet_name" {
+  description = "Virtual network name"
+  type        = string
+}
+
+variable "address_space" {
+  description = "Address space for VNet"
+  type        = list(string)
+}
+
+variable "subnet_cidrs" {
+  description = "CIDRs for subnets"
+  type        = list(string)
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "resource_group" {
+  description = "Resource group name"
+  type        = string
+}

--- a/infrastructure/gcp/container-services/README.md
+++ b/infrastructure/gcp/container-services/README.md
@@ -1,0 +1,15 @@
+# GCP Container Services Module
+
+Provision a simple GKE cluster.
+
+## Usage
+```hcl
+module "gke" {
+  source            = "./infrastructure/gcp/container-services"
+  cluster_name      = "demo-cluster"
+  region            = "us-central1"
+  initial_node_count = 1
+}
+```
+
+Use `terraform init` then `terraform apply` to create the cluster.

--- a/infrastructure/gcp/container-services/main.tf
+++ b/infrastructure/gcp/container-services/main.tf
@@ -1,0 +1,5 @@
+resource "google_container_cluster" "cluster" {
+  name               = var.cluster_name
+  location           = var.region
+  initial_node_count = var.initial_node_count
+}

--- a/infrastructure/gcp/container-services/outputs.tf
+++ b/infrastructure/gcp/container-services/outputs.tf
@@ -1,0 +1,4 @@
+output "cluster_endpoint" {
+  description = "Endpoint of the cluster"
+  value       = google_container_cluster.cluster.endpoint
+}

--- a/infrastructure/gcp/container-services/variables.tf
+++ b/infrastructure/gcp/container-services/variables.tf
@@ -1,0 +1,15 @@
+variable "cluster_name" {
+  description = "Name of the GKE cluster"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for the cluster"
+  type        = string
+}
+
+variable "initial_node_count" {
+  description = "Number of nodes to start with"
+  type        = number
+  default     = 1
+}

--- a/infrastructure/gcp/iam/README.md
+++ b/infrastructure/gcp/iam/README.md
@@ -1,15 +1,16 @@
-# Cloud IAM Roles Module
+# GCP IAM Module
 
-This Terraform module creates Cloud IAM roles with attached policies so services can operate with least privilege.
+Creates a service account and optional custom role.
 
 ## Usage
 ```hcl
-module "iam" {
-  source            = "./infrastructure/iam"
-  role_name         = "demo-role"
-  assume_role_service = "lambda.amazonaws.com"
-  policy_json       = file("./policy.json")
+module "gcp_iam" {
+  source       = "./infrastructure/gcp/iam"
+  account_id   = "demo-sa"
+  display_name = "Demo Service Account"
+  role_id      = "demoRole"
+  permissions  = ["storage.objectViewer"]
 }
 ```
 
-Run `terraform init` and `terraform fmt` in this directory before applying.
+Run `terraform init` and `terraform plan` to preview changes.

--- a/infrastructure/gcp/iam/main.tf
+++ b/infrastructure/gcp/iam/main.tf
@@ -1,2 +1,18 @@
-# Placeholder module for gcp iam. Replace with provider-specific resources.
-resource "null_resource" "placeholder" {}
+resource "google_service_account" "sa" {
+  account_id   = var.account_id
+  display_name = var.display_name
+}
+
+resource "google_project_iam_custom_role" "role" {
+  count       = length(var.permissions) > 0 ? 1 : 0
+  role_id     = var.role_id
+  title       = var.role_id
+  permissions = var.permissions
+}
+
+resource "google_service_account_iam_member" "binding" {
+  count  = length(var.permissions) > 0 ? 1 : 0
+  service_account_id = google_service_account.sa.name
+  role    = google_project_iam_custom_role.role[0].name
+  member  = "serviceAccount:${google_service_account.sa.email}"
+}

--- a/infrastructure/gcp/iam/outputs.tf
+++ b/infrastructure/gcp/iam/outputs.tf
@@ -1,3 +1,4 @@
-output "id" {
-  value = null_resource.placeholder.id
+output "service_account_email" {
+  description = "Email of the service account"
+  value       = google_service_account.sa.email
 }

--- a/infrastructure/gcp/iam/variables.tf
+++ b/infrastructure/gcp/iam/variables.tf
@@ -1,14 +1,21 @@
-variable "role_name" {
-  description = "Name of the IAM role"
+variable "account_id" {
+  description = "Service account ID"
   type        = string
 }
 
-variable "assume_role_service" {
-  description = "Service that can assume this role"
+variable "display_name" {
+  description = "Display name"
   type        = string
 }
 
-variable "policy_json" {
-  description = "JSON policy document"
+variable "role_id" {
+  description = "Custom role ID"
   type        = string
+  default     = "customRole"
+}
+
+variable "permissions" {
+  description = "Permissions for the custom role"
+  type        = list(string)
+  default     = []
 }

--- a/infrastructure/gcp/networking/README.md
+++ b/infrastructure/gcp/networking/README.md
@@ -1,0 +1,15 @@
+# GCP Networking Module
+
+Provision a VPC network and subnets in Google Cloud.
+
+## Usage
+```hcl
+module "gcp_network" {
+  source       = "./infrastructure/gcp/networking"
+  network_name = "demo"
+  region       = "us-central1"
+  subnet_cidrs = ["10.10.1.0/24", "10.10.2.0/24"]
+}
+```
+
+Initialize with `terraform init` then run `terraform plan`.

--- a/infrastructure/gcp/networking/main.tf
+++ b/infrastructure/gcp/networking/main.tf
@@ -1,0 +1,12 @@
+resource "google_compute_network" "main" {
+  name                    = var.network_name
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnets" {
+  count         = length(var.subnet_cidrs)
+  name          = "${var.network_name}-subnet-${count.index}"
+  ip_cidr_range = var.subnet_cidrs[count.index]
+  region        = var.region
+  network       = google_compute_network.main.id
+}

--- a/infrastructure/gcp/networking/outputs.tf
+++ b/infrastructure/gcp/networking/outputs.tf
@@ -1,0 +1,4 @@
+output "network_id" {
+  description = "ID of the network"
+  value       = google_compute_network.main.id
+}

--- a/infrastructure/gcp/networking/variables.tf
+++ b/infrastructure/gcp/networking/variables.tf
@@ -1,0 +1,14 @@
+variable "network_name" {
+  description = "Name of the network"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for subnets"
+  type        = string
+}
+
+variable "subnet_cidrs" {
+  description = "CIDR ranges for subnets"
+  type        = list(string)
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -279,3 +279,6 @@ This file records brief summaries of each pull request.
 - CI workflow now runs the new scanning tools.
 - Added `docs/security-scanning.md` and updated README.
 - Logged completion of task 153 in `tasks_status.md`.
+- Added multi-cloud Terraform modules for Azure and GCP with container services, networking and IAM.
+- Orchestrator now accepts `provider` parameter and triggers provider-specific deploy webhooks.
+- Documented usage in `docs/multi-cloud.md` and marked task 154 complete.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -155,3 +155,4 @@
 | 151    | Collaborative Workflow Editor          | Completed |
 | 152    | AI-Driven Cost Forecasting               | Completed |
 | 153    | Security Scanning & SBOM Generation      | Completed |
+| 154    | Multi-Cloud Deployment Templates         | Completed |


### PR DESCRIPTION
## Summary
- add multi-cloud Terraform modules for Azure and GCP
- update orchestrator to accept `provider` parameter and use provider specific deploy hooks
- document multi-cloud modules and configuration
- record completion in status and summary files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d9ed6a98c8331983a3d5a4acb637e