### PR TITLE
Implement automatic data migrations

### DIFF
--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -13,6 +13,7 @@ import { initSentry } from '../../packages/shared/src/sentry';
 import { startSelfHealing, configure as configureHealing } from './selfHeal';
 import fs from 'fs';
 import path from 'path';
+import { generateMigrations, Schema } from '../../packages/migrations/src';
 import {
   CloudWatchClient,
   GetMetricStatisticsCommand,
@@ -190,7 +191,13 @@ app.get('/api/schema', (_req, res) => {
 });
 
 app.post('/api/schema', (req, res) => {
-  fs.writeFileSync(SCHEMA_FILE, JSON.stringify(req.body, null, 2));
+  const schema = req.body as Schema;
+  fs.writeFileSync(SCHEMA_FILE, JSON.stringify(schema, null, 2));
+  try {
+    generateMigrations(schema);
+  } catch (err) {
+    console.error('migration generation failed', err);
+  }
   res.json({ ok: true });
 });
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,4 @@ This folder contains user guides and architecture diagrams.
 - [Regional Compliance](./regional-compliance.md)
 - [Localization](./i18n.md)
 - [Dashboard Monitoring](./dashboard-monitoring.md)
+- [Automatic Data Migrations](./automatic-data-migrations.md)

--- a/docs/automatic-data-migrations.md
+++ b/docs/automatic-data-migrations.md
@@ -1,0 +1,9 @@
+# Automatic Data Migrations
+
+Schema changes in the designer are tracked in `schema.history.json`.
+Each new revision is compared to the previous one and simple
+PostgreSQL migration commands are appended to `migrations.sql`.
+
+Run the orchestrator and update the schema via `/api/schema`.
+Migration commands will be generated automatically. Review
+`migrations.sql` before applying to production.

--- a/packages/migrations/README.md
+++ b/packages/migrations/README.md
@@ -1,0 +1,5 @@
+# Schema Migrations
+
+This package generates simple SQL migration scripts based on schema changes.
+It tracks schema revisions locally and outputs idempotent statements for
+PostgreSQL.

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@iac/schema-migrations",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/migrations/src/index.test.ts
+++ b/packages/migrations/src/index.test.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import { diffSchemas, generateMigrations, saveSchema, loadHistory } from './index';
+
+const HISTORY_FILE = process.env.SCHEMA_HISTORY_FILE || 'schema.history.json';
+const MIGRATIONS_FILE = process.env.MIGRATIONS_FILE || 'migrations.sql';
+
+afterEach(() => {
+  if (fs.existsSync(HISTORY_FILE)) fs.unlinkSync(HISTORY_FILE);
+  if (fs.existsSync(MIGRATIONS_FILE)) fs.unlinkSync(MIGRATIONS_FILE);
+});
+
+test('diffSchemas generates create and alter statements', () => {
+  const oldSchema = { tables: [] };
+  const newSchema = {
+    tables: [
+      { name: 'users', columns: [{ name: 'id', type: 'int' }] },
+    ],
+  };
+  const cmds = diffSchemas(oldSchema, newSchema);
+  expect(cmds[0]).toMatch('CREATE TABLE');
+});
+
+test('generateMigrations appends to migration file', () => {
+  const schema1 = { tables: [] };
+  const schema2 = {
+    tables: [
+      { name: 't', columns: [{ name: 'c', type: 'text' }] },
+    ],
+  };
+  generateMigrations(schema1);
+  const cmds = generateMigrations(schema2);
+  expect(cmds.length).toBe(1);
+  expect(fs.readFileSync(MIGRATIONS_FILE, 'utf-8')).toContain('CREATE TABLE');
+  const history = loadHistory();
+  expect(history.length).toBe(2);
+});

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface Column {
+  name: string;
+  type: string;
+}
+
+export interface Table {
+  name: string;
+  columns: Column[];
+}
+
+export interface Schema {
+  tables: Table[];
+}
+
+const HISTORY_FILE = process.env.SCHEMA_HISTORY_FILE || 'schema.history.json';
+const MIGRATIONS_FILE = process.env.MIGRATIONS_FILE || 'migrations.sql';
+
+export function loadHistory(): Schema[] {
+  if (!fs.existsSync(HISTORY_FILE)) return [];
+  return JSON.parse(fs.readFileSync(HISTORY_FILE, 'utf-8')) as Schema[];
+}
+
+export function saveSchema(schema: Schema) {
+  const history = loadHistory();
+  history.push(schema);
+  fs.writeFileSync(HISTORY_FILE, JSON.stringify(history, null, 2));
+}
+
+function findTable(tables: Table[], name: string): Table | undefined {
+  return tables.find((t) => t.name === name);
+}
+
+export function diffSchemas(oldSchema: Schema, newSchema: Schema): string[] {
+  const commands: string[] = [];
+  for (const table of newSchema.tables) {
+    const prev = findTable(oldSchema.tables, table.name);
+    if (!prev) {
+      const cols = table.columns
+        .map((c) => `  ${c.name} ${c.type}`)
+        .join(',\n');
+      commands.push(`CREATE TABLE IF NOT EXISTS ${table.name} (\n${cols}\n);`);
+      continue;
+    }
+    for (const col of table.columns) {
+      if (!prev.columns.find((c) => c.name === col.name)) {
+        commands.push(
+          `ALTER TABLE ${table.name} ADD COLUMN IF NOT EXISTS ${col.name} ${col.type};`
+        );
+      }
+    }
+  }
+  return commands;
+}
+
+export function generateMigrations(newSchema: Schema): string[] {
+  const history = loadHistory();
+  const last = history[history.length - 1];
+  if (last) {
+    const commands = diffSchemas(last, newSchema);
+    if (commands.length) {
+      fs.appendFileSync(MIGRATIONS_FILE, commands.join('\n') + '\n');
+    }
+    saveSchema(newSchema);
+    return commands;
+  }
+  // first schema just stored
+  saveSchema(newSchema);
+  return [];
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -282,3 +282,4 @@ This file records brief summaries of each pull request.
 - Added multi-cloud Terraform modules for Azure and GCP with container services, networking and IAM.
 - Orchestrator now accepts `provider` parameter and triggers provider-specific deploy webhooks.
 - Documented usage in `docs/multi-cloud.md` and marked task 154 complete.
+- Implemented automatic schema migration generation. Added new package `packages/migrations` with diff logic and integrated into orchestrator `/api/schema` endpoint. Documented usage in `docs/automatic-data-migrations.md` and marked task 155 complete.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -156,3 +156,4 @@
 | 152    | AI-Driven Cost Forecasting               | Completed |
 | 153    | Security Scanning & SBOM Generation      | Completed |
 | 154    | Multi-Cloud Deployment Templates         | Completed |
+| 155    | Automatic Data Migrations               | Completed |


### PR DESCRIPTION
## Summary
- introduce `@iac/schema-migrations` package for generating SQL migration scripts
- integrate migration generation into the orchestrator `/api/schema` endpoint
- document usage in `docs/automatic-data-migrations.md`
- record task completion in `tasks_status.md` and `steps_summary.md`

## Testing
- `npx jest` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da188ae7c8331b210f3dccf2dede2