### PR TITLE
Add pair programming chat service

### DIFF
--- a/apps/portal/src/pages/pair-programming.tsx
+++ b/apps/portal/src/pages/pair-programming.tsx
@@ -1,0 +1,68 @@
+import { useState, useEffect } from 'react';
+
+interface Msg { role: 'user' | 'ai'; text: string; }
+
+export default function PairProgramming() {
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const [input, setInput] = useState('');
+  const [file, setFile] = useState('');
+  const [ws, setWs] = useState<WebSocket | null>(null);
+
+  useEffect(() => {
+    const socket = new WebSocket('ws://localhost:4002');
+    socket.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      if (data.type === 'response') {
+        setMessages((m) => [...m, { role: 'ai', text: data.text }]);
+      }
+    };
+    setWs(socket);
+    return () => socket.close();
+  }, []);
+
+  const send = () => {
+    if (!ws) return;
+    ws.send(JSON.stringify({ type: 'ask', file, message: input }));
+    setMessages([...messages, { role: 'user', text: input }]);
+    setInput('');
+  };
+
+  async function applyPatch(text: string) {
+    const match = text.match(/```diff([\s\S]*?)```/);
+    if (!match) return;
+    await fetch('http://localhost:4002/applyPatch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patch: match[1].trim() }),
+    });
+    alert('Patch applied');
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Pair Programming Chat</h1>
+      <input
+        placeholder="File path"
+        value={file}
+        onChange={(e) => setFile(e.target.value)}
+        style={{ width: '100%' }}
+      />
+      <div style={{ marginTop: 10 }}>
+        {messages.map((m, i) => (
+          <div key={i} style={{ whiteSpace: 'pre-wrap', marginBottom: 5 }}>
+            <b>{m.role === 'user' ? 'You' : 'AI'}:</b> {m.text}
+            {m.role === 'ai' && m.text.includes('```diff') && (
+              <button onClick={() => applyPatch(m.text)}>Apply Patch</button>
+            )}
+          </div>
+        ))}
+      </div>
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        style={{ width: '100%', height: 80 }}
+      />
+      <button onClick={send}>Send</button>
+    </div>
+  );
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,3 +19,4 @@ This folder contains user guides and architecture diagrams.
 - [Localization](./i18n.md)
 - [Dashboard Monitoring](./dashboard-monitoring.md)
 - [Automatic Data Migrations](./automatic-data-migrations.md)
+- [AI Pair Programming Chat](./pair-programming-chat.md)

--- a/docs/pair-programming-chat.md
+++ b/docs/pair-programming-chat.md
@@ -1,0 +1,7 @@
+# AI Pair Programming Chat
+
+This service provides a live chat assistant that can read files from the repository and suggest patches.
+
+Run `pnpm --filter @iac/pair-chat build && node services/pair-chat/dist/index.js` to start locally.
+
+Messages are sent over WebSocket and responses include suggested code changes. Patches may contain sensitive data, so keep API keys secret and monitor token usage when using OpenAI.

--- a/services/pair-chat/README.md
+++ b/services/pair-chat/README.md
@@ -1,0 +1,10 @@
+# Pair Programming Chat Service
+
+Provides a websocket endpoint that proxies requests to an LLM and returns coding suggestions.
+
+## Endpoints
+
+- `ws://<host>/` – send `{type: 'ask', file?: string, message: string}` and receive `{type: 'response', text: string}`.
+- `POST /applyPatch` – apply a unified diff patch and commit it.
+
+Set `OPENAI_API_KEY` or `CUSTOM_MODEL_URL` to configure the language model. Patches are committed automatically unless `TEST_MODE` is set.

--- a/services/pair-chat/package.json
+++ b/services/pair-chat/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@iac/pair-chat",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.18.3",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/services/pair-chat/src/index.test.ts
+++ b/services/pair-chat/src/index.test.ts
@@ -1,0 +1,17 @@
+import request from 'supertest';
+import { app } from './index';
+import fs from 'fs';
+
+const DIR = '.test-patches';
+process.env.PATCH_DIR = DIR;
+process.env.TEST_MODE = '1';
+
+afterEach(() => {
+  if (fs.existsSync(DIR)) fs.rmSync(DIR, { recursive: true });
+});
+
+test('saves patch to directory', async () => {
+  const res = await request(app).post('/applyPatch').send({ patch: 'diff' });
+  expect(res.status).toBe(200);
+  expect(fs.existsSync(DIR)).toBe(true);
+});

--- a/services/pair-chat/src/index.ts
+++ b/services/pair-chat/src/index.ts
@@ -1,0 +1,94 @@
+import express from 'express';
+import { WebSocketServer } from 'ws';
+import fetch from 'node-fetch';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { initSentry } from '../../packages/shared/src/sentry';
+import { logAudit } from '../../packages/shared/src/audit';
+import { policyMiddleware } from '../../packages/shared/src/policyMiddleware';
+
+export const app = express();
+app.use(express.json());
+app.use(policyMiddleware);
+app.use((req, _res, next) => {
+  logAudit(`pair-chat ${req.method} ${req.url}`);
+  next();
+});
+
+const PATCH_DIR = process.env.PATCH_DIR || '.patches';
+
+async function sendToModel(prompt: string) {
+  if (process.env.CUSTOM_MODEL_URL) {
+    const r = await fetch(process.env.CUSTOM_MODEL_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt }),
+    });
+    const j = await r.json();
+    return j.result as string;
+  }
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) throw new Error('OPENAI_API_KEY not set');
+  const r = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+  const j = await r.json();
+  return j.choices?.[0]?.message?.content || '';
+}
+
+app.post('/applyPatch', (req, res) => {
+  const patch = req.body.patch;
+  if (!patch) return res.status(400).json({ error: 'missing patch' });
+  if (!fs.existsSync(PATCH_DIR)) fs.mkdirSync(PATCH_DIR);
+  const file = path.join(PATCH_DIR, `${Date.now()}.patch`);
+  fs.writeFileSync(file, patch, 'utf8');
+  if (!process.env.TEST_MODE) {
+    try {
+      execSync(`git apply ${file}`);
+      execSync('git add -A');
+      execSync('git commit -m "chat patch"');
+    } catch (err) {
+      return res.status(500).json({ error: 'apply failed' });
+    }
+  }
+  res.json({ ok: true });
+});
+
+export function start(port = 4002) {
+  initSentry('pair-chat');
+  const server = app.listen(port, () =>
+    console.log(`pair-chat listening on ${port}`)
+  );
+  const wss = new WebSocketServer({ server });
+  wss.on('connection', (ws) => {
+    ws.on('message', async (msg) => {
+      try {
+        const { type, file, message } = JSON.parse(msg.toString());
+        if (type !== 'ask') return;
+        let snippet = '';
+        if (file && fs.existsSync(file)) {
+          snippet = fs.readFileSync(file, 'utf8');
+        }
+        const prompt = `${message}\n\nCurrent code from ${file}:\n${snippet}\n`;
+        const result = await sendToModel(prompt);
+        ws.send(JSON.stringify({ type: 'response', text: result }));
+      } catch (err) {
+        ws.send(JSON.stringify({ type: 'error', error: 'failed' }));
+      }
+    });
+  });
+  return server;
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 4002);
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -299,3 +299,8 @@ This file records brief summaries of each pull request.
 - Created portal page `security.tsx` displaying vulnerability data and policy info.
 - Documented workflow in `docs/security-compliance.md`.
 - Updated task tracker for task 158.
+\n## PR <pending> - Pair programming chat
+- Added new `pair-chat` service exposing a websocket chat endpoint and patch API.
+- Created portal page `pair-programming.tsx` for interactive code suggestions.
+- Documented usage and privacy notes in `docs/pair-programming-chat.md`.
+- Marked task 159 complete in `tasks_status.md`.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -160,3 +160,4 @@
 | 156    | Billing Service & Stripe Integration    | Completed |
 | 157    | AI-Powered UI/UX Optimization           | Completed |
 | 158    | Security & Compliance Dashboard         | Completed |
+| 159    | AI Pair Programming Chat                | Completed |


### PR DESCRIPTION
## Summary
- implement pair-chat service with websocket and patch API
- create portal page for pair programming chat
- document usage in new docs and index
- mark task 159 complete and log steps

## Testing
- `pnpm install` *(fails: No matching version for react-flow-renderer)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db062ea108331a8c1f8a2d614cdb7