### PR TITLE
Implement multi-cloud pricing advisor

### DIFF
--- a/apps/portal/src/README.md
+++ b/apps/portal/src/README.md
@@ -26,4 +26,5 @@ Additional pages:
 - `ethics-dashboard.tsx` – transparency metrics overview
 - `ux-optimization.tsx` – view UI/UX suggestions and adopt improvements
 - `business.tsx` – monetization tips and marketing copy with cost forecasts
+- `pricing.tsx` – multi-cloud pricing advisor comparing AWS, GCP and Azure
  - Translations loaded via `packages/i18n` when `localStorage.lang` is set.

--- a/apps/portal/src/pages/pricing.tsx
+++ b/apps/portal/src/pages/pricing.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import useSWR from 'swr';
+
+const fetcher = (u: string) => fetch(u).then(r => r.json());
+
+export default function Pricing() {
+  const [cpu, setCpu] = useState('10');
+  const [memory, setMemory] = useState('20');
+  const [regions, setRegions] = useState('us-east-1,us-central1,eastus');
+  const [failover, setFailover] = useState(false);
+  const { data } = useSWR(
+    `/pricing/recommend?cpu=${cpu}&memory=${memory}&regions=${regions}&failover=${failover}`,
+    fetcher
+  );
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Multi-Cloud Pricing Advisor</h1>
+      <div>
+        <label>
+          CPU Hours
+          <input value={cpu} onChange={e => setCpu(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Memory GB Hours
+          <input value={memory} onChange={e => setMemory(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Regions (comma separated)
+          <input value={regions} onChange={e => setRegions(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Failover
+          <input
+            type="checkbox"
+            checked={failover}
+            onChange={e => setFailover(e.target.checked)}
+          />
+        </label>
+      </div>
+      {data && (
+        <p style={{ marginTop: 20 }}>
+          Cheapest option: {data.recommendation.provider} in{' '}
+          {data.recommendation.region} costing ${'{'}data.recommendation.cost.toFixed(2){'}'}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/services/pricing/README.md
+++ b/services/pricing/README.md
@@ -1,0 +1,12 @@
+# Pricing Service
+
+Provides simple multi-cloud cost estimates and recommendations.
+
+## Endpoints
+
+- `GET /estimate?provider=aws&region=us-east-1&cpu=10&memory=20` – returns cost estimate based on hours of CPU and GB of memory.
+- `GET /recommend?cpu=10&memory=20&regions=us-east-1,europe-west1&failover=true` – compares all providers and returns the cheapest option.
+
+Prices are loaded from `prices.json` and cached in `.cache.json` for 24 hours.
+
+Run `pnpm start --filter pricing-service` to launch the service on port 3008.

--- a/services/pricing/package.json
+++ b/services/pricing/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pricing-service",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "lint": "echo linting pricing-service",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/pricing/prices.json
+++ b/services/pricing/prices.json
@@ -1,0 +1,14 @@
+{
+  "aws": {
+    "us-east-1": { "cpu": 0.031, "memory": 0.004 },
+    "us-west-2": { "cpu": 0.032, "memory": 0.0041 }
+  },
+  "gcp": {
+    "us-central1": { "cpu": 0.033, "memory": 0.0042 },
+    "europe-west1": { "cpu": 0.034, "memory": 0.0043 }
+  },
+  "azure": {
+    "eastus": { "cpu": 0.035, "memory": 0.0044 },
+    "westeurope": { "cpu": 0.036, "memory": 0.0045 }
+  }
+}

--- a/services/pricing/src/index.test.ts
+++ b/services/pricing/src/index.test.ts
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import { app } from './index';
+import fs from 'fs';
+import path from 'path';
+
+const CACHE = path.join(__dirname, '..', '.cache.json');
+
+afterEach(() => {
+  if (fs.existsSync(CACHE)) fs.unlinkSync(CACHE);
+});
+
+test('estimates cost for provider and region', async () => {
+  const res = await request(app).get('/estimate').query({
+    provider: 'aws',
+    region: 'us-east-1',
+    cpu: 10,
+    memory: 20,
+  });
+  expect(res.body.cost).toBeGreaterThan(0);
+});
+
+test('recommends cheapest option', async () => {
+  const res = await request(app).get('/recommend').query({
+    cpu: 5,
+    memory: 5,
+  });
+  expect(res.body.recommendation.provider).toBeDefined();
+});

--- a/services/pricing/src/index.ts
+++ b/services/pricing/src/index.ts
@@ -1,0 +1,98 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import { policyMiddleware } from '../../packages/shared/src/policyMiddleware';
+import { logAudit } from '../../packages/shared/src/audit';
+
+export const app = express();
+app.use(express.json());
+app.use(policyMiddleware);
+app.use((req, _res, next) => {
+  logAudit(`pricing ${req.method} ${req.url}`);
+  next();
+});
+
+const DATA_FILE = path.join(__dirname, '..', 'prices.json');
+const CACHE_FILE = path.join(__dirname, '..', '.cache.json');
+
+interface Price {
+  cpu: number; // per hour
+  memory: number; // per GB hour
+}
+
+interface PriceMap {
+  [provider: string]: {
+    [region: string]: Price;
+  };
+}
+
+function loadPrices(): PriceMap {
+  if (fs.existsSync(CACHE_FILE)) {
+    const cached = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf-8'));
+    if (Date.now() - cached.time < 24 * 3600 * 1000) {
+      return cached.prices as PriceMap;
+    }
+  }
+  const prices: PriceMap = JSON.parse(fs.readFileSync(DATA_FILE, 'utf-8'));
+  fs.writeFileSync(
+    CACHE_FILE,
+    JSON.stringify({ time: Date.now(), prices }, null, 2)
+  );
+  return prices;
+}
+
+function computeCost(price: Price, cpu: number, memory: number) {
+  return cpu * price.cpu + memory * price.memory;
+}
+
+app.get('/estimate', (_req, res) => {
+  const { provider, region, cpu = '0', memory = '0' } = _req.query as {
+    provider?: string;
+    region?: string;
+    cpu?: string;
+    memory?: string;
+  };
+  const prices = loadPrices();
+  if (!provider || !region || !prices[provider]?.[region]) {
+    return res.status(400).json({ error: 'invalid provider or region' });
+  }
+  const cost = computeCost(
+    prices[provider][region],
+    Number(cpu),
+    Number(memory)
+  );
+  res.json({ provider, region, cost });
+});
+
+app.get('/recommend', (_req, res) => {
+  const { cpu = '0', memory = '0', regions, failover } = _req.query as {
+    cpu?: string;
+    memory?: string;
+    regions?: string;
+    failover?: string;
+  };
+  const cpuNum = Number(cpu);
+  const memNum = Number(memory);
+  const limitRegions = regions ? regions.split(',') : undefined;
+  const prices = loadPrices();
+  let best: { provider: string; region: string; cost: number } | null = null;
+  for (const [provider, regionsMap] of Object.entries(prices)) {
+    for (const [region, price] of Object.entries(regionsMap)) {
+      if (limitRegions && !limitRegions.includes(region)) continue;
+      let cost = computeCost(price, cpuNum, memNum);
+      if (failover === 'true') cost *= 2;
+      if (!best || cost < best.cost) {
+        best = { provider, region, cost };
+      }
+    }
+  }
+  res.json({ recommendation: best });
+});
+
+export function start(port = 3008) {
+  app.listen(port, () => console.log(`pricing service listening on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3008);
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -320,3 +320,9 @@ This file records brief summaries of each pull request.
 - Analytics service now exposes `/businessTips` returning revenue ideas and marketing copy.
 - Portal page `business.tsx` displays tips alongside cost forecasts.
 - Added documentation in `docs/business-tips.md` and updated task tracker for task 163.
+
+## PR <pending> - Multi-cloud pricing advisor
+- Created `pricing-service` with `/estimate` and `/recommend` endpoints.
+- Added `pricing.tsx` portal page for interactive cost comparisons.
+- Sample price data cached in `.cache.json` under `services/pricing`.
+- Documented usage in `services/pricing/README.md` and referenced in portal README.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -165,3 +165,4 @@
 | 161    | Monetized Plugin Marketplace           | Completed |
 | 162    | Real-Time Stream Processing Connectors | Completed |
 | 163    | AI Business & Monetization Recommendations | Completed |
+| 164    | Multi-Cloud Pricing Advisor            | Completed |


### PR DESCRIPTION
## Summary
- add pricing service with estimate and recommend endpoints
- expose pricing advisor page in portal
- document pricing service usage and portal update
- mark task 164 complete and summarize changes

## Testing
- `pnpm test` *(fails: turbo not found)*
- `npx jest services/pricing/src/index.test.ts` *(failed: required package jest missing)*

------
https://chatgpt.com/codex/tasks/task_e_686dd050bad88331ae5acb8b9f909220