### PR TITLE
Add ecommerce template

### DIFF
--- a/packages/codegen-templates/src/templates/ecommerce/Cart.tsx
+++ b/packages/codegen-templates/src/templates/ecommerce/Cart.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export interface CartItem {
+  name: string;
+  price: number;
+}
+
+export interface CartProps {
+  items: CartItem[];
+  onCheckout: () => void;
+}
+
+export function Cart({ items, onCheckout }: CartProps) {
+  const total = items.reduce((sum, i) => sum + i.price, 0);
+  return (
+    <div>
+      <h2>Cart</h2>
+      <ul>
+        {items.map((it, i) => (
+          <li key={i}>
+            {it.name} - ${it.price.toFixed(2)}
+          </li>
+        ))}
+      </ul>
+      <strong>Total: ${total.toFixed(2)}</strong>
+      <button onClick={onCheckout}>Checkout</button>
+    </div>
+  );
+}

--- a/packages/codegen-templates/src/templates/ecommerce/Checkout.tsx
+++ b/packages/codegen-templates/src/templates/ecommerce/Checkout.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { stripeConnector } from '@iac/data-connectors';
+
+export interface CartItem {
+  name: string;
+  price: number;
+}
+
+export interface CheckoutProps {
+  items: CartItem[];
+  stripeKey: string;
+  analyticsUrl?: string;
+}
+
+export function Checkout({ items, stripeKey, analyticsUrl }: CheckoutProps) {
+  const pay = async () => {
+    await stripeConnector({ apiKey: stripeKey });
+    if (analyticsUrl) {
+      await fetch(`${analyticsUrl}/events`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'purchase', value: items.length }),
+      });
+    }
+    alert('Payment processed');
+  };
+
+  return (
+    <div>
+      <h2>Checkout</h2>
+      <button onClick={pay}>Pay Now</button>
+    </div>
+  );
+}

--- a/packages/codegen-templates/src/templates/ecommerce/Product.tsx
+++ b/packages/codegen-templates/src/templates/ecommerce/Product.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export interface ProductProps {
+  name: string;
+  price: number;
+  onAdd: () => void;
+}
+
+export function Product({ name, price, onAdd }: ProductProps) {
+  return (
+    <div>
+      <h3>{name}</h3>
+      <p>${price.toFixed(2)}</p>
+      <button onClick={onAdd}>Add to Cart</button>
+    </div>
+  );
+}

--- a/packages/codegen-templates/src/templates/ecommerce/README.md
+++ b/packages/codegen-templates/src/templates/ecommerce/README.md
@@ -1,0 +1,25 @@
+# E-Commerce Template
+
+This template provides a simple storefront with React components and API routes.
+It uses the Stripe connector for payments and records purchase events via the
+analytics service. Shipping and tax rates can be customized through environment
+variables.
+
+## Files
+
+- `Product.tsx` – display a single product
+- `Cart.tsx` – show cart contents and total
+- `Checkout.tsx` – process payments and send analytics events
+- `server.ts` – example Express API for products and checkout
+
+## Setup
+
+1. Set `STRIPE_KEY` with your Stripe secret key.
+2. Optionally set `ANALYTICS_URL` to point at the analytics service.
+3. Customize the `PRODUCTS`, `SHIPPING_RATE` and `TAX_RATE` constants in
+   `server.ts` or via environment variables.
+4. Run `ts-node server.ts` to start the API and open the React components in
+your frontend.
+
+This template can be extended to integrate marketing emails or inventory
+management as needed.

--- a/packages/codegen-templates/src/templates/ecommerce/server.ts
+++ b/packages/codegen-templates/src/templates/ecommerce/server.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import { stripeConnector } from '@iac/data-connectors';
+import fetch from 'node-fetch';
+
+const PRODUCTS = [
+  { id: 1, name: 'Sample Product', price: 20 },
+];
+const SHIPPING_RATE = Number(process.env.SHIPPING_RATE || '5');
+const TAX_RATE = Number(process.env.TAX_RATE || '0.07');
+const STRIPE_KEY = process.env.STRIPE_KEY || 'sk_test_key';
+const ANALYTICS_URL = process.env.ANALYTICS_URL || '';
+
+export const app = express();
+app.use(express.json());
+
+app.get('/products', (_req, res) => {
+  res.json(PRODUCTS);
+});
+
+app.post('/checkout', async (req, res) => {
+  const items = req.body.items || [];
+  await stripeConnector({ apiKey: STRIPE_KEY });
+  const total = items.reduce((sum: number, i: any) => sum + i.price, 0);
+  const price = total + SHIPPING_RATE + total * TAX_RATE;
+  if (ANALYTICS_URL) {
+    await fetch(`${ANALYTICS_URL}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'purchase', value: price }),
+    });
+  }
+  res.json({ ok: true, charged: price });
+});
+
+const port = Number(process.env.PORT || '4000');
+app.listen(port, () => console.log(`ecommerce api listening on ${port}`));

--- a/packages/codegen-templates/src/templates/index.ts
+++ b/packages/codegen-templates/src/templates/index.ts
@@ -7,4 +7,5 @@ export const templates = [
   { name: 'fastapi', description: 'Python FastAPI boilerplate' },
   { name: 'go', description: 'Go REST API boilerplate' },
   { name: 'mobile', description: 'React Native starter app' },
+  { name: 'ecommerce', description: 'React storefront with Stripe' },
 ];

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -327,3 +327,8 @@ This file records brief summaries of each pull request.
 - Sample price data cached in `.cache.json` under `services/pricing`.
 - Documented usage in `services/pricing/README.md` and referenced in portal README.
 \n## PR <pending> - App Store Deployment Automation\n- Added Apple and Google publishing connectors and new /api/publishMobile endpoint.\n- Portal page mobile-publish.tsx triggers submissions.\n- Script publish-mobile.js wraps fastlane commands.\n- Documentation and task tracker updated for task 165.
+
+## PR <pending> - E-Commerce Starter Template
+- Added new `ecommerce` template under `packages/codegen-templates` with React components and example API routes.
+- Template integrates Stripe payments and posts purchase events to the analytics service.
+- Updated template registry and marked task 166 complete.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -167,3 +167,4 @@
 | 163    | AI Business & Monetization Recommendations | Completed |
 | 164    | Multi-Cloud Pricing Advisor            | Completed |
 | 165    | App Store Deployment Automation    | Completed |
+| 166    | E-Commerce Starter Template           | Completed |


### PR DESCRIPTION
## Summary
- add ecommerce starter template with cart, product, checkout components
- include example API routes leveraging Stripe and analytics service
- document setup and usage
- register new template and mark task 166 complete

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dea1f46d4833195437aea09830e57