### PR TITLE
Add migration runner script

### DIFF
--- a/docs/automatic-data-migrations.md
+++ b/docs/automatic-data-migrations.md
@@ -6,4 +6,13 @@ PostgreSQL migration commands are appended to `migrations.sql`.
 
 Run the orchestrator and update the schema via `/api/schema`.
 Migration commands will be generated automatically. Review
-`migrations.sql` before applying to production.
+`migrations.sql` before applying to production. Use the provided
+`tools/run-migrations.js` script to execute pending migrations
+against your PostgreSQL database:
+
+```bash
+pnpm run migrate -- --connection postgres://user:pass@localhost:5432/db
+```
+
+The script maintains a `migrations` table and only applies files that
+have not been executed yet.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "security:scan": "node tools/security/scan.js",
     "sbom": "node tools/security/generate-sbom.js",
     "security:audit": "node tools/security-audit.js",
-    "preview": "node tools/start-preview.js"
+    "preview": "node tools/start-preview.js",
+    "migrate": "node tools/run-migrations.js"
   },
   "devDependencies": {
     "@aws-sdk/client-cloudwatch": "^3.841.0",

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -299,10 +299,12 @@ This file records brief summaries of each pull request.
 - Created portal page `security.tsx` displaying vulnerability data and policy info.
 - Documented workflow in `docs/security-compliance.md`.
 - Updated task tracker for task 158.
-\n## PR <pending> - Pair programmer chat\n- Added WebSocket /chat endpoint in orchestrator with LLM forwarding.\n- Chat widget integrated into portal.\n- Analytics service stores conversations for fine-tuning.\n- Documented setup and privacy in docs/pair-programmer.md.
-\n## PR <pending> - Preview environments\n- Added Terraform module `infrastructure/preview` for ephemeral ECS services.\n- Implemented preview management in orchestrator with new `preview.ts`.\n- Created CI workflow `ci/preview.yml` and helper script.\n- Documented usage in `docs/preview-environments.md`.\n- Marked task 160 complete.
-\n
+  \n## PR <pending> - Pair programmer chat\n- Added WebSocket /chat endpoint in orchestrator with LLM forwarding.\n- Chat widget integrated into portal.\n- Analytics service stores conversations for fine-tuning.\n- Documented setup and privacy in docs/pair-programmer.md.
+  \n## PR <pending> - Preview environments\n- Added Terraform module `infrastructure/preview` for ephemeral ECS services.\n- Implemented preview management in orchestrator with new `preview.ts`.\n- Created CI workflow `ci/preview.yml` and helper script.\n- Documented usage in `docs/preview-environments.md`.\n- Marked task 160 complete.
+  \n
+
 ## PR <pending> - Monetized plugin marketplace
+
 - Marketplace service supports paid plugins with `/purchase` and license validation.
 - Plugin interface updated with pricing fields.
 - Portal marketplace page handles buying and installing with license keys.
@@ -310,6 +312,7 @@ This file records brief summaries of each pull request.
 - Documentation updated and task 161 completed.
 
 ## PR <pending> - Real-Time Stream Processing Connectors
+
 - Added Kafka and Kinesis helpers in `@iac/data-connectors` with basic validation.
 - Orchestrator connector API now stores stream settings and exposes `/api/testStream`.
 - Portal connectors page updated with fields for broker, topic and stream info.
@@ -317,21 +320,28 @@ This file records brief summaries of each pull request.
 - Marked task 162 complete.
 
 ## PR <pending> - Business monetization recommendations
+
 - Analytics service now exposes `/businessTips` returning revenue ideas and marketing copy.
 - Portal page `business.tsx` displays tips alongside cost forecasts.
 - Added documentation in `docs/business-tips.md` and updated task tracker for task 163.
 
 ## PR <pending> - Multi-cloud pricing advisor
+
 - Created `pricing-service` with `/estimate` and `/recommend` endpoints.
 - Added `pricing.tsx` portal page for interactive cost comparisons.
 - Sample price data cached in `.cache.json` under `services/pricing`.
 - Documented usage in `services/pricing/README.md` and referenced in portal README.
-\n## PR <pending> - App Store Deployment Automation\n- Added Apple and Google publishing connectors and new /api/publishMobile endpoint.\n- Portal page mobile-publish.tsx triggers submissions.\n- Script publish-mobile.js wraps fastlane commands.\n- Documentation and task tracker updated for task 165.
+  \n## PR <pending> - App Store Deployment Automation\n- Added Apple and Google publishing connectors and new /api/publishMobile endpoint.\n- Portal page mobile-publish.tsx triggers submissions.\n- Script publish-mobile.js wraps fastlane commands.\n- Documentation and task tracker updated for task 165.
 
 ## PR <pending> - E-Commerce Starter Template
+
 - Added new `ecommerce` template under `packages/codegen-templates` with React components and example API routes.
 - Template integrates Stripe payments and posts purchase events to the analytics service.
 - Updated template registry and marked task 166 complete.
 
 ## Maintenance
+
 - Locked react-flow-renderer version to ^10.3.17 to avoid installation failure.
+- Added `tools/run-migrations.js` and npm script `migrate` for applying schema
+  migrations. Updated documentation in `docs/automatic-data-migrations.md` and
+  `tools/README.md`.

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,6 +11,7 @@ Utility scripts for local development and deployment.
 - `offline.sh` – spin up all services locally without external dependencies
 - `audit-log.js` – append audit events to a log file
 - `export-data.js` – export or delete tenant data for GDPR requests
+- `run-migrations.js` – apply generated SQL files to a Postgres database
 
 - `loadtest/basic.js` – example k6 script
 
@@ -18,4 +19,12 @@ Utility scripts for local development and deployment.
 
 ```
 node tools/redeploy.js --id abc123 --description "New features" --url http://localhost:3002
+```
+
+### Run Migrations
+
+Apply pending migrations to a local Postgres database:
+
+```
+pnpm run migrate -- --connection postgres://user:pass@localhost:5432/db
 ```

--- a/tools/run-migrations.js
+++ b/tools/run-migrations.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+const { Command } = require('commander');
+const { Client } = require('pg');
+const fs = require('fs');
+const path = require('path');
+
+const program = new Command();
+program
+  .requiredOption('-c, --connection <str>', 'postgres connection string')
+  .option(
+    '-d, --dir <path>',
+    'migrations directory',
+    'packages/codegen-templates/migrations'
+  );
+
+program.parse(process.argv);
+const opts = program.opts();
+
+(async () => {
+  const client = new Client({ connectionString: opts.connection });
+  await client.connect();
+  await client.query(
+    'CREATE TABLE IF NOT EXISTS migrations (id text primary key)'
+  );
+  const res = await client.query('SELECT id FROM migrations');
+  const applied = new Set(res.rows.map((r) => r.id));
+  const files = fs
+    .readdirSync(opts.dir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  for (const file of files) {
+    if (applied.has(file)) continue;
+    const sql = fs.readFileSync(path.join(opts.dir, file), 'utf8');
+    try {
+      await client.query('BEGIN');
+      await client.query(sql);
+      await client.query('INSERT INTO migrations(id) VALUES($1)', [file]);
+      await client.query('COMMIT');
+      console.log('applied', file);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      console.error('failed', file, err.message);
+      process.exitCode = 1;
+      break;
+    }
+  }
+  await client.end();
+})();


### PR DESCRIPTION
## Summary
- add `tools/run-migrations.js` helper to apply SQL migrations
- expose script via `pnpm run migrate`
- document migration usage
- update steps summary

## Testing
- `npx prettier -w docs/automatic-data-migrations.md tools/README.md package.json steps_summary.md tools/run-migrations.js`
- `node tools/run-migrations.js --help` *(fails: Cannot find module 'commander')*

------
https://chatgpt.com/codex/tasks/task_e_686ed26808508331a1feaf2c4618608c