### PR TITLE
Improve stream connectors validation

### DIFF
--- a/packages/data-connectors/README.md
+++ b/packages/data-connectors/README.md
@@ -2,4 +2,6 @@
 
 Example connectors that third-party services can implement. This package currently includes functional connectors for Stripe, Slack, Shopify, QuickBooks, Zendesk, Kafka and Kinesis using their HTTP APIs and SDKs. It also provides publishing helpers for the Apple App Store and Google Play.
 
+The Kafka and Kinesis helpers now validate required options before attempting connections, throwing descriptive errors when configuration is incomplete.
+
 TensorFlow.js models can be placed under `model/` and loaded in the browser with `tfHelper.ts` for client-side inference. Prediction helpers are also exported for server-side endpoints.

--- a/packages/data-connectors/src/kafka.test.ts
+++ b/packages/data-connectors/src/kafka.test.ts
@@ -1,8 +1,15 @@
 jest.mock('kafkajs', () => {
-  const producer = { connect: jest.fn(), send: jest.fn(), disconnect: jest.fn() };
+  const producer = {
+    connect: jest.fn(),
+    send: jest.fn(),
+    disconnect: jest.fn(),
+  };
   const consumer = { connect: jest.fn(), subscribe: jest.fn(), run: jest.fn() };
   return {
-    Kafka: jest.fn(() => ({ producer: () => producer, consumer: () => consumer })),
+    Kafka: jest.fn(() => ({
+      producer: () => producer,
+      consumer: () => consumer,
+    })),
     logLevel: { NOTHING: 0 },
   };
 });
@@ -15,13 +22,39 @@ test('produceKafka sends message', async () => {
   expect(instance.producer().send).toHaveBeenCalled();
 });
 
+test('produceKafka validates options', async () => {
+  await expect(produceKafka({ brokers: [], topic: 't' }, 'm')).rejects.toThrow(
+    'missing brokers'
+  );
+  await expect(
+    produceKafka({ brokers: ['b'], topic: '' }, 'm')
+  ).rejects.toThrow('missing topic');
+});
+
 test('consumeKafka calls handler', async () => {
   const handler = jest.fn();
   const { Kafka } = require('kafkajs');
-  const consumer = { connect: jest.fn(), subscribe: jest.fn(), run: jest.fn(async (cfg) => {
-    await cfg.eachMessage({ message: { value: Buffer.from('x') } });
-  }) };
-  Kafka.mockImplementation(() => ({ producer: jest.fn(), consumer: () => consumer }));
+  const consumer = {
+    connect: jest.fn(),
+    subscribe: jest.fn(),
+    run: jest.fn(async (cfg) => {
+      await cfg.eachMessage({ message: { value: Buffer.from('x') } });
+    }),
+  };
+  Kafka.mockImplementation(() => ({
+    producer: jest.fn(),
+    consumer: () => consumer,
+  }));
   await consumeKafka({ brokers: ['b'], topic: 't' }, handler);
   expect(handler).toHaveBeenCalledWith('x');
+});
+
+test('consumeKafka validates options', async () => {
+  const handler = jest.fn();
+  await expect(
+    consumeKafka({ brokers: [], topic: 't' }, handler)
+  ).rejects.toThrow('missing brokers');
+  await expect(
+    consumeKafka({ brokers: ['b'], topic: '' }, handler)
+  ).rejects.toThrow('missing topic');
 });

--- a/packages/data-connectors/src/kafka.ts
+++ b/packages/data-connectors/src/kafka.ts
@@ -7,8 +7,17 @@ export interface KafkaOptions {
   sasl?: SASLOptions;
 }
 
-export async function produceKafka(opts: KafkaOptions, message: string): Promise<void> {
-  if (!opts.brokers.length) throw new Error('missing brokers');
+function validateKafkaOptions(opts: KafkaOptions) {
+  if (!opts.brokers || opts.brokers.length === 0)
+    throw new Error('missing brokers');
+  if (!opts.topic) throw new Error('missing topic');
+}
+
+export async function produceKafka(
+  opts: KafkaOptions,
+  message: string
+): Promise<void> {
+  validateKafkaOptions(opts);
   const kafka = new Kafka({
     brokers: opts.brokers,
     ssl: opts.ssl,
@@ -25,7 +34,7 @@ export async function consumeKafka(
   opts: KafkaOptions,
   onMessage: (msg: string) => Promise<void>
 ): Promise<void> {
-  if (!opts.brokers.length) throw new Error('missing brokers');
+  validateKafkaOptions(opts);
   const kafka = new Kafka({
     brokers: opts.brokers,
     ssl: opts.ssl,

--- a/packages/data-connectors/src/kinesis.test.ts
+++ b/packages/data-connectors/src/kinesis.test.ts
@@ -1,16 +1,21 @@
 jest.mock('@aws-sdk/client-kinesis', () => {
   const send = jest.fn(async (cmd) => {
-    if (cmd.constructor.name === 'ListShardsCommand') return { Shards: [{ ShardId: '1' }] };
-    if (cmd.constructor.name === 'GetShardIteratorCommand') return { ShardIterator: 'it' };
-    if (cmd.constructor.name === 'GetRecordsCommand') return { Records: [{ Data: Buffer.from('y') }] };
+    if (cmd.constructor.name === 'ListShardsCommand')
+      return { Shards: [{ ShardId: '1' }] };
+    if (cmd.constructor.name === 'GetShardIteratorCommand')
+      return { ShardIterator: 'it' };
+    if (cmd.constructor.name === 'GetRecordsCommand')
+      return { Records: [{ Data: Buffer.from('y') }] };
     return {};
   });
-  class KinesisClient { send = send }
+  class KinesisClient {
+    send = send;
+  }
   const cmds = {
-    PutRecordCommand: function() {},
-    ListShardsCommand: function() {},
-    GetShardIteratorCommand: function() {},
-    GetRecordsCommand: function() {},
+    PutRecordCommand: function () {},
+    ListShardsCommand: function () {},
+    GetShardIteratorCommand: function () {},
+    GetRecordsCommand: function () {},
   };
   return { KinesisClient, ...cmds };
 });
@@ -23,8 +28,21 @@ test('putKinesis sends record', async () => {
   expect(client.send).toHaveBeenCalled();
 });
 
+test('putKinesis validates options', async () => {
+  await expect(putKinesis({ streamName: '' }, 'd')).rejects.toThrow(
+    'missing streamName'
+  );
+});
+
 test('consumeKinesis processes records', async () => {
   const handler = jest.fn();
   await consumeKinesis({ streamName: 's' }, handler);
   expect(handler).toHaveBeenCalledWith('y');
+});
+
+test('consumeKinesis validates options', async () => {
+  const handler = jest.fn();
+  await expect(consumeKinesis({ streamName: '' }, handler)).rejects.toThrow(
+    'missing streamName'
+  );
 });

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -345,3 +345,4 @@ This file records brief summaries of each pull request.
 - Added `tools/run-migrations.js` and npm script `migrate` for applying schema
   migrations. Updated documentation in `docs/automatic-data-migrations.md` and
   `tools/README.md`.
+- Added option validation for Kafka and Kinesis connectors with accompanying tests.


### PR DESCRIPTION
## Summary
- validate required Kafka and Kinesis options
- add corresponding tests
- document new validation behavior

## Testing
- `pnpm install --ignore-scripts`
- `pnpm exec jest packages/data-connectors --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_686ed6dcada88331b20955ebb6f59b71