### PR TITLE
Enhance business tip heuristics

### DIFF
--- a/docs/business-tips.md
+++ b/docs/business-tips.md
@@ -18,6 +18,9 @@ Tips are generated from event counts including `purchase`, `trialStart` and
 `conversion` types. When `OPENAI_API_KEY` is configured, a short marketing blurb
 is produced using the OpenAI API.
 
+Additional heuristics suggest discounts when many trials have little purchase
+activity.
+
 ## Portal
 
 The portal page `business.tsx` displays the returned tips next to the cost

--- a/services/analytics/src/index.test.ts
+++ b/services/analytics/src/index.test.ts
@@ -52,9 +52,17 @@ test('chat history persists', async () => {
 });
 
 test('business tips endpoint returns tips', async () => {
-  await request(app).post('/events').send({ type: 'trialStart', userId: 'u1' });
-  await request(app).post('/events').send({ type: 'trialStart', userId: 'u2' });
+  for (let i = 0; i < 5; i++) {
+    await request(app)
+      .post('/events')
+      .send({ type: 'trialStart', userId: `u${i}` });
+  }
   const res = await request(app).get('/businessTips');
   expect(res.status).toBe(200);
   expect(Array.isArray(res.body.tips)).toBe(true);
+  expect(
+    res.body.tips.includes(
+      'Offer incentives like discounts to convert trial users.'
+    )
+  ).toBe(true);
 });

--- a/services/analytics/src/index.ts
+++ b/services/analytics/src/index.ts
@@ -213,6 +213,9 @@ function generateBusinessTips(events: any[]): string[] {
   if (trials > 0 && conversions / trials < 0.2) {
     tips.push('Improve onboarding to boost trial conversions.');
   }
+  if (trials >= 5 && purchases < trials / 10) {
+    tips.push('Offer incentives like discounts to convert trial users.');
+  }
   if (tips.length === 0) tips.push('No monetization tips at this time.');
   return tips;
 }

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -346,3 +346,4 @@ This file records brief summaries of each pull request.
   migrations. Updated documentation in `docs/automatic-data-migrations.md` and
   `tools/README.md`.
 - Added option validation for Kafka and Kinesis connectors with accompanying tests.
+- Refined business tip generation with discount suggestion.


### PR DESCRIPTION
## Summary
- tweak analytics service to suggest discounts when trials exceed purchases
- document new heuristic in business tips doc
- update business tips test
- note update in steps summary

## Testing
- `pnpm install`
- `npm test` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_686ee16d3f5083319d5a78c61730674c