### PR TITLE
Add tasks 190-195

### DIFF
--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -2358,3 +2358,75 @@ This file expands on each item in `Tasks.md` with a short description of the exp
     3. Modify `offline-model/Dockerfile` to accept optimized weights.
     4. Document usage in `docs/offline-llm-optimization.md`.
 
+190. **Natural Language ChatOps**
+
+   - Parse human requests in Slack into orchestrator commands.
+   - Maintain conversation memory to clarify ambiguous input.
+   - Log interactions for analytics.
+   - Task details: Enhance `services/plugins/chatops` with NLP parsing using a lightweight model.
+  - Steps:
+    1. Add `nlp.ts` helper in `services/plugins/chatops`.
+    2. Expose `/api/chatops/nlp` for processing messages.
+    3. Persist conversation context in `services/analytics`.
+    4. Document new commands in `services/plugins/chatops/README.md`.
+
+191. **Reusable AR Gesture Library**
+
+   - Provide a shared set of gestures for AR layout editing.
+   - Importable by any AR-enabled portal page.
+   - Allow customization of gesture sensitivity.
+   - Task details: Implement `packages/ar-gestures` and update `portal/ar` to use it.
+  - Steps:
+    1. Create the library `packages/ar-gestures/index.ts`.
+    2. Define common gestures with TypeScript types.
+    3. Update `portal/ar` to load gestures from the package.
+    4. Document extension points in `packages/ar-gestures/README.md`.
+
+192. **Federated Training Privacy Dashboard**
+
+   - Visualize aggregation metrics and privacy noise levels.
+   - Show opt-in statistics across tenants.
+   - Provide alerts if thresholds are exceeded.
+   - Task details: Extend `services/federated-training` with metric storage and a portal dashboard.
+  - Steps:
+    1. Record noise levels in `services/federated-training/metrics.ts`.
+    2. Add `/api/privacyStats` endpoints in the orchestrator.
+    3. Build `portal/privacy-dashboard.tsx` to display charts.
+    4. Document interpretation guidance in `docs/federated-privacy.md`.
+
+193. **Cross-Chain Plugin License Sync**
+
+   - Mirror plugin license records across multiple blockchains.
+   - Handle chain failures gracefully with retries.
+   - Provide a CLI to resync past transactions.
+   - Task details: Update blockchain helpers to support bridging between Ethereum and Polygon.
+  - Steps:
+    1. Expand `packages/data-connectors/blockchain.ts` with bridge APIs.
+    2. Queue sync jobs in `services/plugins` for new purchases.
+    3. Implement a `tools/resync-licenses.ts` script.
+    4. Document configuration in `docs/cross-chain-licensing.md`.
+
+194. **Edge Auto-Scaling**
+
+   - Dynamically scale edge deployments based on request metrics.
+   - Integrate scaling policies with the orchestrator.
+   - Provide dashboards showing active edge instances.
+   - Task details: Add auto-scaling Terraform modules and orchestrator hooks.
+  - Steps:
+    1. Create `infrastructure/edge/auto-scaling.tf` with provider configs.
+    2. Emit usage metrics from edge functions to `services/analytics`.
+    3. Add orchestrator logic to update scaling settings.
+    4. Explain setup in `docs/edge-auto-scaling.md`.
+
+195. **Prompt A/B Testing Platform**
+
+   - Run experiments comparing multiple prompt variants.
+   - Collect success metrics and recommend winners.
+   - Allow exporting results for further analysis.
+   - Task details: Build `services/prompt-experiments` with portal integration.
+  - Steps:
+    1. Scaffold the service under `services/prompt-experiments`.
+    2. Add endpoints `/api/experiments` for CRUD operations.
+    3. Implement `portal/prompt-tests.tsx` to launch and monitor tests.
+    4. Document workflows in `docs/prompt-ab-testing.md`.
+

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -87,7 +87,8 @@ This file records brief summaries of each pull request.
 - Added SHA3-based signing helpers in `packages/shared` and integrated them with the auth service.
 - Created tests for the new crypto module.
 - Updated task tracker for tasks 120-124.
-  \n## PR <pending> - CI improvements and observability updates\n\n- Added release pipeline and dependency scan workflows under `ci/`.\n- Enabled Nx Cloud remote caching via updated `turbo.json`.\n- Enhanced observability Terraform module with log retention and alarms.\n- Documented Sentry DSN usage and added example env vars.\n- Introduced basic Cypress tests and updated package scripts.\n- Updated task tracker for tasks 63-68.
+  
+## PR <pending> - CI improvements and observability updates\n\n- Added release pipeline and dependency scan workflows under `ci/`.\n- Enabled Nx Cloud remote caching via updated `turbo.json`.\n- Enhanced observability Terraform module with log retention and alarms.\n- Documented Sentry DSN usage and added example env vars.\n- Introduced basic Cypress tests and updated package scripts.\n- Updated task tracker for tasks 63-68.
 
 ## PR <pending> - OAuth, analytics and portal pages
 
@@ -282,7 +283,8 @@ This file records brief summaries of each pull request.
 - Orchestrator now accepts `provider` parameter and triggers provider-specific deploy webhooks.
 - Documented usage in `docs/multi-cloud.md` and marked task 154 complete.
 - Implemented automatic schema migration generation. Added new package `packages/migrations` with diff logic and integrated into orchestrator `/api/schema` endpoint. Documented usage in `docs/automatic-data-migrations.md` and marked task 155 complete.
-  \n## PR <pending> - Billing service and portal integration\n\n- Added new `billing-service` microservice with subscription and invoice endpoints.\n- Created portal billing page to manage plans and view invoices.\n- Documented configuration in `docs/billing-service.md`.\n- Updated task tracker for task 156.
+  
+## PR <pending> - Billing service and portal integration\n\n- Added new `billing-service` microservice with subscription and invoice endpoints.\n- Created portal billing page to manage plans and view invoices.\n- Documented configuration in `docs/billing-service.md`.\n- Updated task tracker for task 156.
 
 ## PR <pending> - AI-powered UI/UX optimization
 
@@ -299,8 +301,10 @@ This file records brief summaries of each pull request.
 - Created portal page `security.tsx` displaying vulnerability data and policy info.
 - Documented workflow in `docs/security-compliance.md`.
 - Updated task tracker for task 158.
-  \n## PR <pending> - Pair programmer chat\n- Added WebSocket /chat endpoint in orchestrator with LLM forwarding.\n- Chat widget integrated into portal.\n- Analytics service stores conversations for fine-tuning.\n- Documented setup and privacy in docs/pair-programmer.md.
-  \n## PR <pending> - Preview environments\n- Added Terraform module `infrastructure/preview` for ephemeral ECS services.\n- Implemented preview management in orchestrator with new `preview.ts`.\n- Created CI workflow `ci/preview.yml` and helper script.\n- Documented usage in `docs/preview-environments.md`.\n- Marked task 160 complete.
+  
+## PR <pending> - Pair programmer chat\n- Added WebSocket /chat endpoint in orchestrator with LLM forwarding.\n- Chat widget integrated into portal.\n- Analytics service stores conversations for fine-tuning.\n- Documented setup and privacy in docs/pair-programmer.md.
+  
+## PR <pending> - Preview environments\n- Added Terraform module `infrastructure/preview` for ephemeral ECS services.\n- Implemented preview management in orchestrator with new `preview.ts`.\n- Created CI workflow `ci/preview.yml` and helper script.\n- Documented usage in `docs/preview-environments.md`.\n- Marked task 160 complete.
   \n
 
 ## PR <pending> - Monetized plugin marketplace
@@ -331,7 +335,8 @@ This file records brief summaries of each pull request.
 - Added `pricing.tsx` portal page for interactive cost comparisons.
 - Sample price data cached in `.cache.json` under `services/pricing`.
 - Documented usage in `services/pricing/README.md` and referenced in portal README.
-  \n## PR <pending> - App Store Deployment Automation\n- Added Apple and Google publishing connectors and new /api/publishMobile endpoint.\n- Portal page mobile-publish.tsx triggers submissions.\n- Script publish-mobile.js wraps fastlane commands.\n- Documentation and task tracker updated for task 165.
+  
+## PR <pending> - App Store Deployment Automation\n- Added Apple and Google publishing connectors and new /api/publishMobile endpoint.\n- Portal page mobile-publish.tsx triggers submissions.\n- Script publish-mobile.js wraps fastlane commands.\n- Documentation and task tracker updated for task 165.
 
 ## PR <pending> - E-Commerce Starter Template
 
@@ -350,5 +355,9 @@ This file records brief summaries of each pull request.
 
 ## PR <pending> - Next-Generation Tasks Added
 - Appended tasks 167 through 184 in `parallel_tasks.md` covering AR previews, federated model training, accessibility audits, synthetic data, blockchain licensing, offline LLM support and other innovations.
-\n## PR <pending> - Advanced collaboration tasks
+
+## PR <pending> - Advanced collaboration tasks
 - Added tasks 185-189 describing collaborative AR sessions, community model sharing, accessibility score tracking, plugin resale features, and offline LLM optimization.
+
+## PR <pending> - Expanded Next-Gen Task List
+- Added tasks 190-195 in `parallel_tasks.md` introducing NLP-based ChatOps, AR gesture library, federated training privacy dashboard, cross-chain licensing sync, edge auto-scaling, and prompt A/B testing.


### PR DESCRIPTION
## Summary
- extend task list with items 190-195 covering NLP ChatOps, AR gesture library, federated training privacy dashboard, cross-chain plugin license sync, edge auto-scaling, and prompt A/B testing
- document the addition in `steps_summary.md`

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686efa7508848331baa483e71be7c9da