### PR TITLE
Implement synthetic data generation service

### DIFF
--- a/apps/orchestrator/src/index.test.ts
+++ b/apps/orchestrator/src/index.test.ts
@@ -306,3 +306,15 @@ test('a11yReport returns scan results', async () => {
   expect(Array.isArray(res.body.violations)).toBe(true);
   fs.unlinkSync(file);
 });
+
+test('syntheticData forwards to service', async () => {
+  const fetchMock = require('node-fetch') as jest.Mock;
+  const res = await request(app)
+    .post('/api/syntheticData')
+    .send({ template: 'user', count: 1 });
+  expect(res.status).toBe(200);
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining('/generate'),
+    expect.objectContaining({ method: 'POST' })
+  );
+});

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -81,6 +81,7 @@ const FORECAST_FILE = path.join(
 );
 const AR_LAYOUT_FILE = process.env.AR_LAYOUT_FILE || 'ar-layout.json';
 const FED_TRAIN_URL = process.env.FED_TRAIN_URL || 'http://localhost:3010';
+const SYN_DATA_URL = process.env.SYN_DATA_URL || 'http://localhost:3011';
 
 async function chatCompletion(message: string): Promise<string> {
   if (process.env.CUSTOM_MODEL_URL) {
@@ -665,6 +666,22 @@ app.post('/api/a11yReport', async (req, res) => {
     res.json({ violations: results.violations });
   } catch {
     res.status(500).json({ error: 'scan failed' });
+  }
+});
+
+app.post('/api/syntheticData', async (req, res) => {
+  const { template, count } = req.body as { template?: string; count?: number };
+  if (!template) return res.status(400).json({ error: 'missing template' });
+  try {
+    const response = await fetch(`${SYN_DATA_URL}/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ template, count }),
+    });
+    const json = await response.json();
+    res.status(response.status).json(json);
+  } catch {
+    res.status(500).json({ error: 'service unavailable' });
   }
 });
 

--- a/docs/synthetic-data.md
+++ b/docs/synthetic-data.md
@@ -1,0 +1,11 @@
+# Synthetic Data Generation
+
+Use the CLI to create anonymized records:
+
+```bash
+pnpm exec ts-node tools/synthetic-data.ts user -c 5 > users.json
+```
+
+The `/api/syntheticData` orchestrator endpoint proxies to the service for remote dataset creation.
+
+Ensure templates are stored under `packages/codegen-templates/data-templates` and avoid sensitive information when sharing generated data.

--- a/packages/codegen-templates/data-templates/README.md
+++ b/packages/codegen-templates/data-templates/README.md
@@ -1,0 +1,4 @@
+# Data Templates
+
+Sample schemas for generating synthetic datasets.
+Use with `tools/synthetic-data.ts` or the synthetic-data service.

--- a/packages/codegen-templates/data-templates/user.json
+++ b/packages/codegen-templates/data-templates/user.json
@@ -1,0 +1,9 @@
+{
+  "fields": [
+    { "name": "id", "type": "uuid" },
+    { "name": "firstName", "type": "firstName" },
+    { "name": "lastName", "type": "lastName" },
+    { "name": "email", "type": "email" },
+    { "name": "age", "type": "number" }
+  ]
+}

--- a/services/synthetic-data/README.md
+++ b/services/synthetic-data/README.md
@@ -1,0 +1,4 @@
+# Synthetic Data Service
+
+Generates anonymized datasets for testing.
+Provides a `/generate` endpoint accepting a template name and count.

--- a/services/synthetic-data/package.json
+++ b/services/synthetic-data/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "synthetic-data-service",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "node ../../node_modules/.bin/tsc",
+    "start": "node dist/index.js",
+    "lint": "echo linting synthetic-data-service",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/synthetic-data/src/index.test.ts
+++ b/services/synthetic-data/src/index.test.ts
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import fs from 'fs';
+import path from 'path';
+import { app, generateData } from './index';
+
+const TEMPLATE_DIR = path.join(__dirname, '..', '..', 'packages', 'codegen-templates', 'data-templates');
+const TEST_SCHEMA = path.join(TEMPLATE_DIR, 'test.json');
+
+beforeAll(() => {
+  if (!fs.existsSync(TEMPLATE_DIR)) fs.mkdirSync(TEMPLATE_DIR, { recursive: true });
+  fs.writeFileSync(TEST_SCHEMA, JSON.stringify({ fields: [{ name: 'id', type: 'uuid' }] }));
+});
+
+afterAll(() => {
+  fs.unlinkSync(TEST_SCHEMA);
+});
+
+test('generateData creates records', () => {
+  const list = generateData('test', 2);
+  expect(list.length).toBe(2);
+  expect(list[0]).toHaveProperty('id');
+});
+
+test('POST /generate returns records', async () => {
+  const res = await request(app).post('/generate').send({ template: 'test', count: 1 });
+  expect(res.status).toBe(200);
+  expect(res.body.data.length).toBe(1);
+});

--- a/services/synthetic-data/src/index.ts
+++ b/services/synthetic-data/src/index.ts
@@ -1,0 +1,98 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { logAudit } from '../../packages/shared/src/audit';
+import { policyMiddleware } from '../../packages/shared/src/policyMiddleware';
+
+export interface Field {
+  name: string;
+  type: string;
+}
+export interface Schema {
+  fields: Field[];
+}
+
+const TEMPLATE_DIR = path.join(
+  __dirname,
+  '..',
+  '..',
+  'packages',
+  'codegen-templates',
+  'data-templates'
+);
+
+export function loadSchema(name: string): Schema {
+  const file = path.join(TEMPLATE_DIR, `${name}.json`);
+  return JSON.parse(fs.readFileSync(file, 'utf-8')) as Schema;
+}
+
+const FIRST = ['Alice', 'Bob', 'Carol', 'Dave'];
+const LAST = ['Smith', 'Jones', 'Lee', 'Brown'];
+
+function sample(arr: string[]) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export function generateRecord(schema: Schema): Record<string, any> {
+  const record: Record<string, any> = {};
+  for (const field of schema.fields) {
+    switch (field.type) {
+      case 'uuid':
+        record[field.name] = randomUUID();
+        break;
+      case 'firstName':
+        record[field.name] = sample(FIRST);
+        break;
+      case 'lastName':
+        record[field.name] = sample(LAST);
+        break;
+      case 'email': {
+        const first = sample(FIRST).toLowerCase();
+        const last = sample(LAST).toLowerCase();
+        record[field.name] = `${first}.${last}@example.com`;
+        break;
+      }
+      case 'number':
+        record[field.name] = Math.floor(Math.random() * 1000);
+        break;
+      default:
+        record[field.name] = Math.random().toString(36).slice(2, 8);
+    }
+  }
+  return record;
+}
+
+export function generateData(template: string, count = 10): any[] {
+  const schema = loadSchema(template);
+  const list = [] as any[];
+  for (let i = 0; i < count; i++) list.push(generateRecord(schema));
+  return list;
+}
+
+export const app = express();
+app.use(express.json());
+app.use(policyMiddleware);
+app.use((req, _res, next) => {
+  logAudit(`synthetic-data ${req.method} ${req.url}`);
+  next();
+});
+
+app.post('/generate', (req, res) => {
+  const { template, count } = req.body as { template?: string; count?: number };
+  if (!template) return res.status(400).json({ error: 'missing template' });
+  try {
+    const data = generateData(template, count || 10);
+    res.json({ data });
+  } catch (err) {
+    res.status(500).json({ error: 'generation failed' });
+  }
+});
+
+export function start(port = 3011) {
+  app.listen(port, () => console.log(`synthetic data service on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3011);
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -380,3 +380,9 @@ This file records brief summaries of each pull request.
 - Added axe-core based scanner `tools/a11y-scan.ts` and `/api/a11yReport` endpoint invoking it.
 - New portal page `a11y.tsx` lists violations and supports marking them fixed.
 - Documented process in `docs/accessibility-audits.md`.
+
+## PR <pending> - Synthetic Data Generation Service
+- Added service `services/synthetic-data` providing dataset generation via `/generate`.
+- New CLI tool `tools/synthetic-data.ts` uses templates under `packages/codegen-templates/data-templates`.
+- Orchestrator endpoint `/api/syntheticData` forwards requests to the service.
+- Documented feature in `docs/synthetic-data.md` and updated tasks list.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -170,3 +170,5 @@
 | 166    | E-Commerce Starter Template                | Completed |
 | 167    | Augmented Reality App Preview              | Completed |
 | 168    | Federated Model Training Service           | Completed |
+| 169    | Accessibility Audit Pipeline              | Completed |
+| 170    | Synthetic Data Generation Service         | Completed |

--- a/tools/synthetic-data.ts
+++ b/tools/synthetic-data.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { generateData } from '../services/synthetic-data/src';
+
+const program = new Command();
+program
+  .argument('<template>', 'template name')
+  .option('-c, --count <number>', 'number of rows', '10')
+  .action((template, options) => {
+    const count = parseInt(options.count, 10) || 10;
+    const data = generateData(template, count);
+    console.log(JSON.stringify(data, null, 2));
+  });
+
+program.parse(process.argv);


### PR DESCRIPTION
## Summary
- add `/api/syntheticData` endpoint in orchestrator
- implement `services/synthetic-data` for generating sample records
- create CLI `tools/synthetic-data.ts`
- provide example data templates
- document synthetic data generation
- mark tasks 169-170 complete

## Testing
- `pnpm exec jest` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_686f2547570083319d5f534142cadb4c