### PR TITLE
Implement Offline LLM support

### DIFF
--- a/apps/codegen/src/localModel.ts
+++ b/apps/codegen/src/localModel.ts
@@ -1,0 +1,12 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { GenerationOptions } from './openai';
+
+const exec = promisify(execFile);
+
+export async function generateWithLocalModel(opts: GenerationOptions): Promise<string> {
+  const modelPath = process.env.LOCAL_MODEL_PATH || 'offline-model/model';
+  const script = process.env.LOCAL_MODEL_SCRIPT || 'offline-model/infer.py';
+  const { stdout } = await exec('python', [script, '--model', modelPath, '--prompt', opts.description, '--lang', opts.language]);
+  return stdout.trim();
+}

--- a/apps/codegen/src/openai.ts
+++ b/apps/codegen/src/openai.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { generateWithCustomModel } from './customModel';
+import { generateWithLocalModel } from './localModel';
 
 export interface GenerationOptions {
   description: string;
@@ -7,6 +8,9 @@ export interface GenerationOptions {
 }
 
 export async function generateCode(opts: GenerationOptions): Promise<string> {
+  if (process.env.LOCAL_MODEL_PATH) {
+    return generateWithLocalModel(opts);
+  }
   if (process.env.CUSTOM_MODEL_URL) {
     return generateWithCustomModel(opts);
   }

--- a/docs/offline-llm.md
+++ b/docs/offline-llm.md
@@ -1,0 +1,35 @@
+# Offline LLM Container
+
+This guide explains how to run the local language model used by the codegen service when network access is not available.
+
+## Hardware Requirements
+
+- 8 GB RAM minimum
+- 10 GB of free disk space
+- CPU with AVX support (GPU optional for fine-tuning)
+
+## Usage
+
+1. Build the container:
+
+```bash
+docker build -f offline-model/Dockerfile -t offline-llm .
+```
+
+2. Start the container:
+
+```bash
+docker run -p 8001:8000 offline-llm
+```
+
+3. Set `CUSTOM_MODEL_URL=http://localhost:8001/generate` and start the codegen service or run `tools/offline.sh` which configures it automatically.
+
+### Fine-tuning
+
+Provide a text file of training data and run:
+
+```bash
+tools/fine-tune-local.sh data/train.txt
+```
+
+New weights are written under `offline-model/finetuned/`.

--- a/offline-model/Dockerfile
+++ b/offline-model/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY serve.py ./serve.py
+COPY fine_tune.py ./fine_tune.py
+COPY infer.py ./infer.py
+RUN pip install --no-cache-dir torch==2.1.0 transformers==4.36.2 flask
+RUN python - <<'PY'
+from transformers import AutoModelForCausalLM, AutoTokenizer
+model = 'distilgpt2'
+AutoModelForCausalLM.from_pretrained(model).save_pretrained('/model')
+AutoTokenizer.from_pretrained(model).save_pretrained('/model')
+PY
+EXPOSE 8000
+CMD ["python","serve.py","--model","/model"]

--- a/offline-model/fine_tune.py
+++ b/offline-model/fine_tune.py
@@ -1,0 +1,39 @@
+import argparse
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+    TextDataset,
+    DataCollatorForLanguageModeling,
+)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--model', required=True)
+parser.add_argument('--data', required=True)
+parser.add_argument('--output', default='finetuned')
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(args.model)
+model = AutoModelForCausalLM.from_pretrained(args.model)
+
+dataset = TextDataset(tokenizer=tokenizer, file_path=args.data, block_size=128)
+collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+training_args = TrainingArguments(
+    output_dir=args.output,
+    overwrite_output_dir=True,
+    num_train_epochs=1,
+    per_device_train_batch_size=1,
+)
+
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=dataset,
+    data_collator=collator,
+)
+
+trainer.train()
+model.save_pretrained(args.output)
+tokenizer.save_pretrained(args.output)

--- a/offline-model/infer.py
+++ b/offline-model/infer.py
@@ -1,0 +1,14 @@
+import argparse
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--model', required=True)
+parser.add_argument('--prompt', required=True)
+parser.add_argument('--lang')
+args = parser.parse_args()
+
+model = AutoModelForCausalLM.from_pretrained(args.model)
+tokenizer = AutoTokenizer.from_pretrained(args.model)
+pipe = pipeline('text-generation', model=model, tokenizer=tokenizer)
+res = pipe(args.prompt, max_new_tokens=200)
+print(res[0]['generated_text'])

--- a/offline-model/serve.py
+++ b/offline-model/serve.py
@@ -1,0 +1,26 @@
+from flask import Flask, request, jsonify
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--model', required=True)
+parser.add_argument('--host', default='0.0.0.0')
+parser.add_argument('--port', type=int, default=8000)
+args = parser.parse_args()
+
+app = Flask(__name__)
+
+model = AutoModelForCausalLM.from_pretrained(args.model)
+tokenizer = AutoTokenizer.from_pretrained(args.model)
+pipe = pipeline('text-generation', model=model, tokenizer=tokenizer)
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    data = request.json or {}
+    prompt = data.get('prompt', '')
+    lang = data.get('language', '')
+    result = pipe(prompt, max_new_tokens=200)
+    return jsonify(result=result[0]['generated_text'])
+
+if __name__ == '__main__':
+    app.run(host=args.host, port=args.port)

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -391,3 +391,11 @@ This file records brief summaries of each pull request.
 - Added blockchain helper module and ledger-based purchase recording.
 - Plugins service now supports `/purchase` and verifies licenses via the ledger.
 - Documented setup in `docs/blockchain-licensing.md` and marked task 171 complete.
+
+## PR <pending> - Offline LLM Support
+
+- Added `offline-model` container with a small Transformers-based API and fine-tuning script.
+- Codegen service now checks `LOCAL_MODEL_PATH` to run generation via the local model.
+- `tools/offline.sh` builds and runs the container automatically and sets `CUSTOM_MODEL_URL`.
+- Created `tools/fine-tune-local.sh` and documented requirements in `docs/offline-llm.md`.
+- Updated task tracker marking task 172 complete.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -173,3 +173,4 @@
 | 169    | Accessibility Audit Pipeline              | Completed |
 | 170    | Synthetic Data Generation Service         | Completed |
 | 171    | Blockchain Plugin Licensing               | Completed |
+| 172    | Offline LLM Support                       | Completed |

--- a/tools/fine-tune-local.sh
+++ b/tools/fine-tune-local.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Fine-tune the offline LLM on a text corpus
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <training-file>"
+  exit 1
+fi
+MODEL=${LOCAL_MODEL_PATH:-offline-model/model}
+python offline-model/fine_tune.py --model "$MODEL" --data "$1" --output offline-model/finetuned

--- a/tools/offline.sh
+++ b/tools/offline.sh
@@ -2,6 +2,9 @@
 # Start dependencies and run all services locally for offline generation
 
 docker-compose up -d
+docker build -f offline-model/Dockerfile -t offline-llm ./offline-model
+docker run -d --rm -p 8001:8000 --name offline-llm offline-llm
+export CUSTOM_MODEL_URL=http://localhost:8001/generate
 pnpm --filter services/email start &
 pnpm --filter services/analytics start &
 pnpm --filter apps/api-auth start &


### PR DESCRIPTION
## Summary
- build local language model container in `offline-model`
- add optional local model generation path in codegen
- update offline startup script and add fine-tuning helper
- document how to run the offline LLM
- mark task 172 complete and note changes in steps summary

## Testing
- `pnpm lint` *(fails: pricing-service#lint)*
- `pnpm test` *(fails: retry#build)*

------
https://chatgpt.com/codex/tasks/task_e_6870238149c483319d6971be53d35507