### PR TITLE
Implement Data Anonymization Tools

### DIFF
--- a/apps/orchestrator/src/index.test.ts
+++ b/apps/orchestrator/src/index.test.ts
@@ -318,3 +318,18 @@ test('syntheticData forwards to service', async () => {
     expect.objectContaining({ method: 'POST' })
   );
 });
+
+test('exportData anonymizes PII fields', async () => {
+  jobMem['j1'] = {
+    id: 'j1',
+    tenantId: 't1',
+    provider: 'aws',
+    description: 'test',
+    language: 'node',
+    status: 'complete',
+    email: 'user@example.com',
+  };
+  const res = await request(app).get('/api/exportData').set('x-tenant-id', 't1');
+  expect(res.status).toBe(200);
+  expect(res.body[0].email).toBe('[REDACTED]');
+});

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -22,6 +22,7 @@ import {
 import { logAudit } from '../../packages/shared/src/audit';
 import { figmaToReact } from '../../packages/shared/src/figma';
 import { policyMiddleware } from '../../packages/shared/src/policyMiddleware';
+import { anonymizeObject } from '../../packages/shared/src/pii';
 import {
   loadModel,
   predict,
@@ -47,6 +48,18 @@ app.use((req, _res, next) => {
   logAudit(`orchestrator ${req.method} ${req.url}`);
   next();
 });
+
+function anonymizeResponse(
+  _req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) {
+  const json = res.json.bind(res);
+  res.json = (body: any) => json(anonymizeObject(body));
+  next();
+}
+
+app.use('/api/exportData', anonymizeResponse);
 
 const JOBS_TABLE = process.env.JOBS_TABLE || 'jobs';
 const CODEGEN_URL = process.env.CODEGEN_URL || 'http://localhost:3003/generate';

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This folder contains user guides and architecture diagrams.
 - [Offline Mode](./offline-mode.md)
 - [Tenant Isolation](./tenant-isolation.md)
 - [GDPR Processes](./gdpr-processes.md)
+- [Data Privacy](./data-privacy.md)
 - [Figma Design Import](./figma-import.md)
 - [Schema Designer](./schema-designer.md)
 - [Voice Guided Modeling](./voice-modeling.md)

--- a/docs/data-privacy.md
+++ b/docs/data-privacy.md
@@ -1,0 +1,17 @@
+# Data Privacy and Anonymization
+
+Exports may contain personally identifiable information (PII). Always scrub sensitive fields before sharing data outside the platform.
+
+## CLI Usage
+
+Use `tools/anonymize-data.ts` to sanitize JSON or CSV files:
+
+```bash
+node tools/anonymize-data.ts --input export.json --output export-anon.json
+```
+
+The script detects common PII fields such as `email` and `phone` and replaces their values with `[REDACTED]`.
+
+## Orchestrator
+
+The `/api/exportData` endpoint automatically anonymizes records before they are returned. You can still run the CLI on any other files you plan to distribute.

--- a/packages/shared/src/pii.test.ts
+++ b/packages/shared/src/pii.test.ts
@@ -1,0 +1,8 @@
+import { anonymizeObject } from './pii';
+
+test('anonymizes known PII fields', () => {
+  const input = { email: 'test@example.com', age: 20 };
+  const result = anonymizeObject(input);
+  expect(result.email).toBe('[REDACTED]');
+  expect(result.age).toBe(20);
+});

--- a/packages/shared/src/pii.ts
+++ b/packages/shared/src/pii.ts
@@ -1,0 +1,30 @@
+export const piiFieldPatterns = [
+  /email/i,
+  /password/i,
+  /phone/i,
+  /address/i,
+  /ssn/i,
+  /name/i,
+];
+
+export function isPiiField(field: string): boolean {
+  return piiFieldPatterns.some((re) => re.test(field));
+}
+
+export function anonymizeObject<T extends Record<string, any>>(obj: T): T {
+  if (Array.isArray(obj)) {
+    return obj.map((o) => anonymizeObject(o)) as unknown as T;
+  }
+  if (obj && typeof obj === 'object') {
+    const copy: any = { ...obj };
+    for (const key of Object.keys(copy)) {
+      if (isPiiField(key)) {
+        copy[key] = '[REDACTED]';
+      } else if (typeof copy[key] === 'object') {
+        copy[key] = anonymizeObject(copy[key]);
+      }
+    }
+    return copy;
+  }
+  return obj;
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -405,3 +405,10 @@ This file records brief summaries of each pull request.
 - Orchestrator forwards scan results and exposes `/api/a11yTips`.
 - Added `A11yTips` React component and `/editor` page to display recommendations.
 - Documented usage in `docs/a11y-assistant.md` and marked task 173 complete.
+
+## PR <pending> - Data Anonymization Tools
+- Created `packages/shared/src/pii.ts` with PII detection patterns and anonymization helpers.
+- Added `tools/anonymize-data.ts` CLI for sanitizing JSON and CSV exports.
+- Orchestrator now anonymizes `/api/exportData` responses via middleware.
+- Wrote unit tests for the new utilities and endpoint behavior.
+- Documented guidance in `docs/data-privacy.md` and marked task 174 complete.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -175,3 +175,4 @@
 | 171    | Blockchain Plugin Licensing               | Completed |
 | 172    | Offline LLM Support                       | Completed |
 | 173    | AI-Based Accessibility Assistant           | Completed |
+| 174    | Data Anonymization Tools                   | Completed |

--- a/tools/anonymize-data.ts
+++ b/tools/anonymize-data.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import fs from 'fs';
+import { anonymizeObject } from '../packages/shared/src/pii';
+
+function inferFormat(file: string): 'json' | 'csv' {
+  return file.endsWith('.csv') ? 'csv' : 'json';
+}
+
+function anonymizeJson(input: string): string {
+  const data = JSON.parse(input);
+  const sanitized = Array.isArray(data)
+    ? data.map((d) => anonymizeObject(d))
+    : anonymizeObject(data);
+  return JSON.stringify(sanitized, null, 2);
+}
+
+function anonymizeCsv(input: string): string {
+  const lines = input.trim().split(/\r?\n/);
+  if (lines.length === 0) return input;
+  const header = lines[0].split(',');
+  const out = [lines[0]];
+  for (const line of lines.slice(1)) {
+    if (!line) continue;
+    const values = line.split(',');
+    const obj: Record<string, string> = {};
+    header.forEach((h, i) => {
+      obj[h] = values[i] || '';
+    });
+    const sanitized = anonymizeObject(obj);
+    out.push(header.map((h) => sanitized[h]).join(','));
+  }
+  return out.join('\n');
+}
+
+const program = new Command();
+program
+  .requiredOption('-i, --input <file>', 'input file')
+  .option('-o, --output <file>', 'output file');
+
+program.parse(process.argv);
+const opts = program.opts();
+
+const format = inferFormat(opts.input);
+const output = opts.output || `anonymized.${format}`;
+const data = fs.readFileSync(opts.input, 'utf8');
+const result = format === 'csv' ? anonymizeCsv(data) : anonymizeJson(data);
+fs.writeFileSync(output, result);
+console.log(`Anonymized data written to ${output}`);


### PR DESCRIPTION
## Summary
- create shared PII detection helpers
- add anonymization CLI for JSON and CSV
- anonymize /api/exportData responses via middleware
- document usage in new data privacy guide
- mark task 174 complete and record work in steps summary

## Testing
- `pnpm exec jest` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68715c2acdbc8331b510e317bd24fe9e