### PR TITLE
Add prompt versioning service

### DIFF
--- a/apps/portal/src/pages/prompts.tsx
+++ b/apps/portal/src/pages/prompts.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import useSWR from 'swr';
+
+const fetcher = (u: string) => fetch(u).then((r) => r.json());
+
+function diff(oldText: string, newText: string): string {
+  if (oldText === newText) return 'No changes';
+  const oldLines = oldText.split('\n');
+  const newLines = newText.split('\n');
+  const out: string[] = [];
+  const max = Math.max(oldLines.length, newLines.length);
+  for (let i = 0; i < max; i++) {
+    const o = oldLines[i] || '';
+    const n = newLines[i] || '';
+    if (o !== n) out.push(`- ${o}\n+ ${n}`);
+  }
+  return out.join('\n');
+}
+
+export default function Prompts() {
+  const { data, mutate } = useSWR('/prompt-store/prompts', fetcher);
+  const [name, setName] = useState('');
+  const [text, setText] = useState('');
+  const [edit, setEdit] = useState<Record<string, string>>({});
+  const [showDiff, setShowDiff] = useState<Record<string, boolean>>({});
+
+  const create = async () => {
+    await fetch('/prompt-store/prompts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, text }),
+    });
+    setName('');
+    setText('');
+    mutate();
+  };
+
+  const update = async (id: string, current: string) => {
+    const newText = edit[id];
+    await fetch(`/prompt-store/prompts/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: newText }),
+    });
+    setShowDiff({ ...showDiff, [id]: false });
+    mutate();
+  };
+
+  const remove = async (id: string) => {
+    await fetch(`/prompt-store/prompts/${id}`, { method: 'DELETE' });
+    mutate();
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Prompt Management</h1>
+      <input
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <textarea
+        placeholder="Prompt"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button onClick={create}>Create</button>
+      <ul>
+        {data &&
+          data.map((p: any) => {
+            const latest = p.versions[p.versions.length - 1].text;
+            const editVal = edit[p.id] ?? latest;
+            return (
+              <li key={p.id} style={{ marginTop: 10 }}>
+                <strong>{p.name}</strong> v{p.versions.length}
+                <br />
+                <textarea
+                  value={editVal}
+                  onChange={(e) => setEdit({ ...edit, [p.id]: e.target.value })}
+                />
+                <button onClick={() => update(p.id, latest)}>Save</button>
+                <button onClick={() => remove(p.id)}>Delete</button>
+                <button
+                  onClick={() =>
+                    setShowDiff({
+                      ...showDiff,
+                      [p.id]: !showDiff[p.id],
+                    })
+                  }
+                >
+                  Diff
+                </button>
+                {showDiff[p.id] && <pre>{diff(latest, editVal)}</pre>}
+              </li>
+            );
+          })}
+      </ul>
+    </div>
+  );
+}

--- a/docs/prompt-management.md
+++ b/docs/prompt-management.md
@@ -1,0 +1,12 @@
+# Prompt Versioning and Management
+
+Prompt templates evolve over time as we refine code generation. The prompt store service keeps a history of each change so previous versions can be reviewed or restored.
+
+## Usage
+
+1. Start `services/prompt-store` and ensure the portal is running.
+2. Navigate to `/prompts` in the portal to create or edit templates.
+3. Edits are saved as new versions. Use the **Diff** button to see changes before saving.
+4. The service stores data in `PROMPT_DB` (default `.prompts.json`).
+
+Version history can be used by analytics to optimize prompts automatically.

--- a/services/prompt-store/README.md
+++ b/services/prompt-store/README.md
@@ -1,0 +1,15 @@
+# Prompt Store Service
+
+This service keeps versions of the prompt templates used by the code generation pipeline.
+
+## Endpoints
+
+- `GET /prompts` – list all stored prompts
+- `POST /prompts` – create a new prompt `{ name, text }`
+- `GET /prompts/:id` – return a prompt and its version history
+- `PUT /prompts/:id` – add a new version `{ text }`
+- `DELETE /prompts/:id` – remove a prompt
+
+The store uses a simple JSON file defined by `PROMPT_DB` (default `.prompts.json`). Each update appends a new version with a timestamp so changes can be audited and rolled back.
+
+Run with `node dist/index.js` after building.

--- a/services/prompt-store/package.json
+++ b/services/prompt-store/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "prompt-store",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p .",
+    "test": "jest",
+    "lint": "eslint src --ext .ts"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/services/prompt-store/src/index.test.ts
+++ b/services/prompt-store/src/index.test.ts
@@ -1,0 +1,36 @@
+import request from 'supertest';
+import fs from 'fs';
+import { app } from './index';
+
+const DB = '.test-prompts.json';
+process.env.PROMPT_DB = DB;
+
+beforeEach(() => {
+  if (fs.existsSync(DB)) fs.unlinkSync(DB);
+});
+
+afterEach(() => {
+  if (fs.existsSync(DB)) fs.unlinkSync(DB);
+});
+
+test('create, update and delete prompt', async () => {
+  const create = await request(app)
+    .post('/prompts')
+    .send({ name: 'greet', text: 'hello' });
+  expect(create.status).toBe(201);
+  const id = create.body.id;
+
+  const update = await request(app)
+    .put(`/prompts/${id}`)
+    .send({ text: 'hi there' });
+  expect(update.status).toBe(200);
+  expect(update.body.versions.length).toBe(2);
+
+  const res = await request(app).get(`/prompts/${id}`);
+  expect(res.body.versions[1].text).toBe('hi there');
+
+  const del = await request(app).delete(`/prompts/${id}`);
+  expect(del.status).toBe(200);
+  const notFound = await request(app).get(`/prompts/${id}`);
+  expect(notFound.status).toBe(404);
+});

--- a/services/prompt-store/src/index.ts
+++ b/services/prompt-store/src/index.ts
@@ -1,0 +1,93 @@
+import express from 'express';
+import fs from 'fs';
+import { randomUUID } from 'crypto';
+import { policyMiddleware } from '../../packages/shared/src/policyMiddleware';
+import { logAudit } from '../../packages/shared/src/audit';
+
+export const app = express();
+app.use(express.json());
+app.use(policyMiddleware);
+app.use((req, _res, next) => {
+  logAudit(`prompt-store ${req.method} ${req.url}`);
+  next();
+});
+
+const DB_FILE = process.env.PROMPT_DB || '.prompts.json';
+
+interface PromptVersion {
+  id: string;
+  text: string;
+  time: number;
+}
+
+interface PromptRecord {
+  id: string;
+  name: string;
+  versions: PromptVersion[];
+}
+
+function read(): PromptRecord[] {
+  return fs.existsSync(DB_FILE)
+    ? (JSON.parse(fs.readFileSync(DB_FILE, 'utf8')) as PromptRecord[])
+    : [];
+}
+
+function save(data: PromptRecord[]) {
+  fs.writeFileSync(DB_FILE, JSON.stringify(data, null, 2));
+}
+
+function find(id: string, list: PromptRecord[]) {
+  return list.find((p) => p.id === id);
+}
+
+app.get('/prompts', (_req, res) => {
+  res.json(read());
+});
+
+app.post('/prompts', (req, res) => {
+  const { name, text } = req.body as { name?: string; text?: string };
+  if (!name || !text) return res.status(400).json({ error: 'missing fields' });
+  const list = read();
+  const record: PromptRecord = {
+    id: randomUUID(),
+    name,
+    versions: [{ id: randomUUID(), text, time: Date.now() }],
+  };
+  list.push(record);
+  save(list);
+  res.status(201).json(record);
+});
+
+app.get('/prompts/:id', (req, res) => {
+  const prompt = find(req.params.id, read());
+  if (!prompt) return res.status(404).json({ error: 'not found' });
+  res.json(prompt);
+});
+
+app.put('/prompts/:id', (req, res) => {
+  const { text } = req.body as { text?: string };
+  if (!text) return res.status(400).json({ error: 'missing text' });
+  const list = read();
+  const prompt = find(req.params.id, list);
+  if (!prompt) return res.status(404).json({ error: 'not found' });
+  prompt.versions.push({ id: randomUUID(), text, time: Date.now() });
+  save(list);
+  res.json(prompt);
+});
+
+app.delete('/prompts/:id', (req, res) => {
+  const list = read();
+  const idx = list.findIndex((p) => p.id === req.params.id);
+  if (idx === -1) return res.status(404).json({ error: 'not found' });
+  list.splice(idx, 1);
+  save(list);
+  res.json({ ok: true });
+});
+
+export function start(port = 3009) {
+  app.listen(port, () => console.log(`prompt-store listening on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3009);
+}

--- a/services/prompt-store/tsconfig.json
+++ b/services/prompt-store/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -377,17 +377,20 @@ This file records brief summaries of each pull request.
 - Implemented NestJS service in services/federated-training to aggregate model updates with differential privacy. Added /api/modelUpdate endpoint in orchestrator and documentation. Marked task 168 complete.
 
 ## PR <pending> - Accessibility Audit Pipeline
+
 - Added axe-core based scanner `tools/a11y-scan.ts` and `/api/a11yReport` endpoint invoking it.
 - New portal page `a11y.tsx` lists violations and supports marking them fixed.
 - Documented process in `docs/accessibility-audits.md`.
 
 ## PR <pending> - Synthetic Data Generation Service
+
 - Added service `services/synthetic-data` providing dataset generation via `/generate`.
 - New CLI tool `tools/synthetic-data.ts` uses templates under `packages/codegen-templates/data-templates`.
 - Orchestrator endpoint `/api/syntheticData` forwards requests to the service.
 - Documented feature in `docs/synthetic-data.md` and updated tasks list.
 
 ## PR <pending> - Blockchain Plugin Licensing
+
 - Added blockchain helper module and ledger-based purchase recording.
 - Plugins service now supports `/purchase` and verifies licenses via the ledger.
 - Documented setup in `docs/blockchain-licensing.md` and marked task 171 complete.
@@ -401,14 +404,23 @@ This file records brief summaries of each pull request.
 - Updated task tracker marking task 172 complete.
 
 ## PR <pending> - AI-Based Accessibility Assistant
+
 - Created new `services/a11y-assistant` Express service storing audit history and returning remediation tips.
 - Orchestrator forwards scan results and exposes `/api/a11yTips`.
 - Added `A11yTips` React component and `/editor` page to display recommendations.
 - Documented usage in `docs/a11y-assistant.md` and marked task 173 complete.
 
 ## PR <pending> - Data Anonymization Tools
+
 - Created `packages/shared/src/pii.ts` with PII detection patterns and anonymization helpers.
 - Added `tools/anonymize-data.ts` CLI for sanitizing JSON and CSV exports.
 - Orchestrator now anonymizes `/api/exportData` responses via middleware.
 - Wrote unit tests for the new utilities and endpoint behavior.
 - Documented guidance in `docs/data-privacy.md` and marked task 174 complete.
+
+## PR <pending> - Prompt Versioning and Management
+
+- Added new `services/prompt-store` Express service to store prompt templates with version history.
+- Implemented CRUD endpoints and accompanying Jest tests.
+- Created `portal/prompts.tsx` page for editing prompts and viewing diffs.
+- Documented workflow in `docs/prompt-management.md` and updated task tracker for task 175.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -170,9 +170,10 @@
 | 166    | E-Commerce Starter Template                | Completed |
 | 167    | Augmented Reality App Preview              | Completed |
 | 168    | Federated Model Training Service           | Completed |
-| 169    | Accessibility Audit Pipeline              | Completed |
-| 170    | Synthetic Data Generation Service         | Completed |
-| 171    | Blockchain Plugin Licensing               | Completed |
-| 172    | Offline LLM Support                       | Completed |
+| 169    | Accessibility Audit Pipeline               | Completed |
+| 170    | Synthetic Data Generation Service          | Completed |
+| 171    | Blockchain Plugin Licensing                | Completed |
+| 172    | Offline LLM Support                        | Completed |
 | 173    | AI-Based Accessibility Assistant           | Completed |
 | 174    | Data Anonymization Tools                   | Completed |
+| 175    | Prompt Versioning and Management           | Completed |


### PR DESCRIPTION
## Summary
- implement Prompt Versioning and Management
- add `prompt-store` service with CRUD API
- create `/prompts` portal page for editing templates and showing diffs
- document workflow in `docs/prompt-management.md`
- mark task 175 complete and log summary

## Testing
- `pnpm exec jest services/prompt-store/src/index.test.ts`
- `pnpm exec turbo run lint` *(fails: command not found or build errors)*

------
https://chatgpt.com/codex/tasks/task_e_687166cce59c8331816f499c8f51f66f