### PR TITLE
Implement query optimizer service

### DIFF
--- a/apps/portal/src/pages/query-optimization.tsx
+++ b/apps/portal/src/pages/query-optimization.tsx
@@ -1,0 +1,30 @@
+import useSWR from 'swr';
+
+const fetcher = (u: string) => fetch(u).then((r) => r.json());
+
+export default function QueryOptimization() {
+  const { data, mutate } = useSWR('/query-optimizer/recommendations', fetcher);
+
+  const apply = async (id: string) => {
+    await fetch(`/query-optimizer/recommendations/${id}/apply`, {
+      method: 'POST',
+    });
+    mutate();
+  };
+
+  if (!data) return <p>Loading...</p>;
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Query Optimization Suggestions</h1>
+      {data.map((r: any) => (
+        <div key={r.id} style={{ marginBottom: 10 }}>
+          <pre>{r.query}</pre>
+          <p>{r.suggestion}</p>
+          {!r.applied && <button onClick={() => apply(r.id)}>Apply</button>}
+          {r.applied && <span>Applied</span>}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs/query-optimization.md
+++ b/docs/query-optimization.md
@@ -1,0 +1,11 @@
+# Query Optimization
+
+This service collects slow query statistics and suggests indexes or rewrites.
+
+## Enable Profiling
+
+Call `POST /stats` from your application whenever a database query runs, sending `{ appId, query, duration }` in milliseconds. The `packages/shared` helper can be used for convenience.
+
+## Viewing Recommendations
+
+Start the service and open `/query-optimization` in the portal to review suggestions. Click **Apply** to mark them addressed so future deployments include the optimizations.

--- a/packages/shared/src/README.md
+++ b/packages/shared/src/README.md
@@ -28,4 +28,11 @@ This package now includes DynamoDB helper functions built on the AWS SDK v3 `Dyn
 ## Input Sanitization
 
 `sanitize(str)` HTML-escapes user supplied strings to prevent injection attacks.
-\n## Audit Logging\n\n`logAudit(msg)` appends a timestamped entry to `AUDIT_LOG` (default `audit.log`).
+
+## Audit Logging
+
+`logAudit(msg)` appends a timestamped entry to `AUDIT_LOG` (default `audit.log`).
+
+## Query Profiling
+
+`recordQuery(appId, query, duration)` posts query metrics to the query optimizer service for analysis.

--- a/packages/shared/src/queryProfiler.test.ts
+++ b/packages/shared/src/queryProfiler.test.ts
@@ -1,0 +1,11 @@
+import { recordQuery } from './queryProfiler';
+import fetch from 'node-fetch';
+
+jest.mock('node-fetch');
+const mocked = fetch as jest.MockedFunction<typeof fetch>;
+
+test('recordQuery posts stats', async () => {
+  mocked.mockResolvedValue({ ok: true } as any);
+  await recordQuery('app1', 'SELECT', 10);
+  expect(mocked).toHaveBeenCalled();
+});

--- a/packages/shared/src/queryProfiler.ts
+++ b/packages/shared/src/queryProfiler.ts
@@ -1,0 +1,19 @@
+import fetch from 'node-fetch';
+
+const SERVICE_URL = process.env.QUERY_OPTIMIZER_URL || 'http://localhost:3015';
+
+export async function recordQuery(
+  appId: string,
+  query: string,
+  duration: number
+) {
+  try {
+    await fetch(`${SERVICE_URL}/stats`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ appId, query, duration }),
+    });
+  } catch {
+    // ignore errors
+  }
+}

--- a/services/query-optimizer/README.md
+++ b/services/query-optimizer/README.md
@@ -1,0 +1,11 @@
+# Query Optimizer Service
+
+Records query execution statistics and suggests optimizations.
+
+## Endpoints
+
+- `POST /stats` – record a query duration `{ appId, query, duration }`
+- `GET /recommendations` – list optimization suggestions (filter with `appId`)
+- `POST /recommendations/:id/apply` – mark a recommendation as applied
+
+Run with `node dist/index.js` after building.

--- a/services/query-optimizer/package.json
+++ b/services/query-optimizer/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "query-optimizer-service",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "node ../../node_modules/.bin/tsc",
+    "start": "node dist/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/query-optimizer/src/index.test.ts
+++ b/services/query-optimizer/src/index.test.ts
@@ -1,0 +1,41 @@
+import request from 'supertest';
+import fs from 'fs';
+import { app } from './index';
+
+const STATS = '.test-query-stats.json';
+const RECS = '.test-query-recs.json';
+
+beforeEach(() => {
+  process.env.QUERY_STATS_DB = STATS;
+  process.env.REC_DB = RECS;
+  process.env.SLOW_QUERY_MS = '1';
+  if (fs.existsSync(STATS)) fs.unlinkSync(STATS);
+  if (fs.existsSync(RECS)) fs.unlinkSync(RECS);
+});
+
+afterEach(() => {
+  if (fs.existsSync(STATS)) fs.unlinkSync(STATS);
+  if (fs.existsSync(RECS)) fs.unlinkSync(RECS);
+});
+
+test('creates recommendation from stats', async () => {
+  await request(app)
+    .post('/stats')
+    .send({ appId: 'a1', query: 'SELECT', duration: 5 });
+  const res = await request(app).get('/recommendations');
+  expect(res.status).toBe(200);
+  expect(res.body.length).toBe(1);
+  expect(res.body[0]).toHaveProperty('query', 'SELECT');
+});
+
+test('apply endpoint marks recommendation', async () => {
+  await request(app)
+    .post('/stats')
+    .send({ appId: 'a1', query: 'SELECT', duration: 5 });
+  const recs = await request(app).get('/recommendations');
+  const id = recs.body[0].id;
+  const res = await request(app).post(`/recommendations/${id}/apply`);
+  expect(res.status).toBe(200);
+  const final = await request(app).get('/recommendations');
+  expect(final.body[0].applied).toBe(true);
+});

--- a/services/query-optimizer/src/index.ts
+++ b/services/query-optimizer/src/index.ts
@@ -1,0 +1,128 @@
+import express from 'express';
+import fs from 'fs';
+import { randomUUID } from 'crypto';
+import { policyMiddleware } from '../../packages/shared/src/policyMiddleware';
+import { logAudit } from '../../packages/shared/src/audit';
+
+export const app = express();
+app.use(express.json());
+app.use(policyMiddleware);
+app.use((req, _res, next) => {
+  logAudit(`query-optimizer ${req.method} ${req.url}`);
+  next();
+});
+
+const STATS_DB = process.env.QUERY_STATS_DB || '.query-stats.json';
+const REC_DB = process.env.REC_DB || '.query-recs.json';
+const SLOW_MS = Number(process.env.SLOW_QUERY_MS || '200');
+
+interface Stat {
+  id: string;
+  appId: string;
+  query: string;
+  duration: number;
+  time: number;
+}
+
+interface Recommendation {
+  id: string;
+  appId: string;
+  query: string;
+  suggestion: string;
+  applied?: boolean;
+}
+
+function readStats(): Stat[] {
+  return fs.existsSync(STATS_DB)
+    ? (JSON.parse(fs.readFileSync(STATS_DB, 'utf8')) as Stat[])
+    : [];
+}
+
+function saveStats(list: Stat[]) {
+  fs.writeFileSync(STATS_DB, JSON.stringify(list, null, 2));
+}
+
+function readRecs(): Recommendation[] {
+  return fs.existsSync(REC_DB)
+    ? (JSON.parse(fs.readFileSync(REC_DB, 'utf8')) as Recommendation[])
+    : [];
+}
+
+function saveRecs(list: Recommendation[]) {
+  fs.writeFileSync(REC_DB, JSON.stringify(list, null, 2));
+}
+
+function analyze() {
+  const stats = readStats();
+  const recs = readRecs();
+  const grouped: Record<
+    string,
+    { total: number; count: number; query: string; appId: string }
+  > = {};
+  for (const s of stats) {
+    const key = `${s.appId}|${s.query}`;
+    const g = grouped[key] || {
+      total: 0,
+      count: 0,
+      query: s.query,
+      appId: s.appId,
+    };
+    g.total += s.duration;
+    g.count++;
+    grouped[key] = g;
+  }
+  for (const g of Object.values(grouped)) {
+    const avg = g.total / g.count;
+    if (
+      avg > SLOW_MS &&
+      !recs.find((r) => r.appId === g.appId && r.query === g.query)
+    ) {
+      recs.push({
+        id: randomUUID(),
+        appId: g.appId,
+        query: g.query,
+        suggestion: `Consider indexing or rewriting query: ${g.query}`,
+      });
+    }
+  }
+  saveRecs(recs);
+}
+
+app.post('/stats', (req, res) => {
+  const { appId, query, duration } = req.body as {
+    appId?: string;
+    query?: string;
+    duration?: number;
+  };
+  if (!appId || !query || typeof duration !== 'number') {
+    return res.status(400).json({ error: 'invalid payload' });
+  }
+  const list = readStats();
+  list.push({ id: randomUUID(), appId, query, duration, time: Date.now() });
+  saveStats(list);
+  analyze();
+  res.status(201).json({ ok: true });
+});
+
+app.get('/recommendations', (req, res) => {
+  const appId = req.query.appId as string | undefined;
+  const recs = readRecs().filter((r) => !appId || r.appId === appId);
+  res.json(recs);
+});
+
+app.post('/recommendations/:id/apply', (req, res) => {
+  const list = readRecs();
+  const rec = list.find((r) => r.id === req.params.id);
+  if (!rec) return res.status(404).json({ error: 'not found' });
+  rec.applied = true;
+  saveRecs(list);
+  res.json({ ok: true });
+});
+
+export function start(port = 3015) {
+  app.listen(port, () => console.log(`query optimizer listening on ${port}`));
+}
+
+if (require.main === module) {
+  start(Number(process.env.PORT) || 3015);
+}

--- a/services/query-optimizer/tsconfig.json
+++ b/services/query-optimizer/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -424,3 +424,10 @@ This file records brief summaries of each pull request.
 - Implemented CRUD endpoints and accompanying Jest tests.
 - Created `portal/prompts.tsx` page for editing prompts and viewing diffs.
 - Documented workflow in `docs/prompt-management.md` and updated task tracker for task 175.
+
+## PR <pending> - AI-Driven Query Optimization
+
+- Created `services/query-optimizer` Express service to record query stats and generate recommendations.
+- Added portal page `query-optimization.tsx` for viewing and applying suggestions.
+- Introduced `recordQuery` helper in `packages/shared` with tests.
+- Documented usage in `docs/query-optimization.md` and updated task tracker for task 176.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -177,3 +177,4 @@
 | 173    | AI-Based Accessibility Assistant           | Completed |
 | 174    | Data Anonymization Tools                   | Completed |
 | 175    | Prompt Versioning and Management           | Completed |
+| 176    | AI-Driven Query Optimization               | Completed |


### PR DESCRIPTION
## Summary
- add Query Optimizer service to record query stats and suggest improvements
- expose new `/query-optimization` portal page
- provide `recordQuery` helper in shared package
- document usage and update task tracker

## Testing
- `npx jest` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687175211df48331a71c30557555fcff