### PR TITLE
Add blockchain connectors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This folder contains user guides and architecture diagrams.
 - [AR Preview](./ar-preview.md)
 - [Template Marketplace](./template-marketplace.md)
 - [Pair Programmer Chat](./pair-programmer.md)
+- [Blockchain Connectors](./blockchain-connectors.md)
 - [Regional Compliance](./regional-compliance.md)
 - [Localization](./i18n.md)
 - [Dashboard Monitoring](./dashboard-monitoring.md)

--- a/docs/blockchain-connectors.md
+++ b/docs/blockchain-connectors.md
@@ -1,0 +1,27 @@
+# Blockchain Connectors
+
+The data connectors package provides helpers for interacting with Ethereum and Polygon networks. These wrappers use JSON-RPC via `ethers` and let generated apps query balances or send native token transactions.
+
+## Usage
+
+```ts
+import { ethereumConnector, polygonConnector } from '@iac/data-connectors';
+
+const eth = ethereumConnector({
+  rpcUrl: 'https://mainnet.infura.io/v3/<id>',
+  privateKey: process.env.PRIV_KEY,
+});
+const balance = await eth.getBalance('0xYourAddress');
+const txHash = await eth.sendTransaction(
+  '0xReceiver',
+  BigInt(1_000_000_000_000_000n)
+);
+
+const poly = polygonConnector({
+  rpcUrl: 'https://polygon-rpc.com',
+  privateKey: process.env.PRIV_KEY,
+});
+await poly.sendTransaction('0xReceiver', BigInt(1_000_000_000_000_000n));
+```
+
+Set your RPC URL and private key through the portal connectors page. Only specify a private key if you need to send transactions; read-only operations just require the RPC URL.

--- a/packages/data-connectors/README.md
+++ b/packages/data-connectors/README.md
@@ -1,6 +1,6 @@
 # Data Connectors
 
-Example connectors that third-party services can implement. This package currently includes functional connectors for Stripe, Slack, Shopify, QuickBooks, Zendesk, Kafka and Kinesis using their HTTP APIs and SDKs. It also provides publishing helpers for the Apple App Store and Google Play.
+Example connectors that third-party services can implement. This package currently includes functional connectors for Stripe, Slack, Shopify, QuickBooks, Zendesk, Kafka, Kinesis and now Ethereum and Polygon using their HTTP APIs and SDKs. It also provides publishing helpers for the Apple App Store and Google Play.
 
 The Kafka and Kinesis helpers now validate required options before attempting connections, throwing descriptive errors when configuration is incomplete.
 

--- a/packages/data-connectors/src/index.ts
+++ b/packages/data-connectors/src/index.ts
@@ -9,6 +9,7 @@ export * from './tfHelper';
 export * from './blockchain';
 export * from './kafka';
 export * from './kinesis';
+import { ethereumConnector, polygonConnector } from './blockchain';
 
 export async function stripeConnector(config: ConnectorConfig) {
   const res = await fetch('https://api.stripe.com/v1/charges', {
@@ -85,3 +86,15 @@ export async function googleConnector(config: ConnectorConfig) {
   );
   if (!res.ok) throw new Error('Google publish failed');
 }
+
+export const connectorRegistry = {
+  stripe: stripeConnector,
+  slack: slackConnector,
+  shopify: shopifyConnector,
+  quickBooks: quickBooksConnector,
+  zendesk: zendeskConnector,
+  apple: appleConnector,
+  google: googleConnector,
+  ethereum: ethereumConnector,
+  polygon: polygonConnector,
+};

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -431,3 +431,10 @@ This file records brief summaries of each pull request.
 - Added portal page `query-optimization.tsx` for viewing and applying suggestions.
 - Introduced `recordQuery` helper in `packages/shared` with tests.
 - Documented usage in `docs/query-optimization.md` and updated task tracker for task 176.
+
+## PR <pending> - Blockchain Connectors
+
+- Added Ethereum and Polygon connector helpers in `packages/data-connectors`.
+- Updated connector registry and README documentation.
+- Created usage guide `docs/blockchain-connectors.md`.
+- Added Jest tests mocking `ethers` in `tests/blockchain`.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -178,3 +178,4 @@
 | 174    | Data Anonymization Tools                   | Completed |
 | 175    | Prompt Versioning and Management           | Completed |
 | 176    | AI-Driven Query Optimization               | Completed |
+| 177    | Blockchain Connectors                      | Completed |

--- a/tests/blockchain/connectors.test.ts
+++ b/tests/blockchain/connectors.test.ts
@@ -1,0 +1,37 @@
+jest.mock('ethers', () => {
+  return {
+    JsonRpcProvider: jest.fn(() => ({
+      getBalance: jest.fn(async () => BigInt(5)),
+    })),
+    Wallet: jest.fn(() => ({
+      sendTransaction: jest.fn(async () => ({
+        wait: async () => undefined,
+        hash: '0xtx',
+      })),
+    })),
+  };
+});
+
+import {
+  ethereumConnector,
+  polygonConnector,
+} from '../../packages/data-connectors/src/blockchain';
+
+test('ethereum connector reads balance', async () => {
+  const eth = ethereumConnector({ rpcUrl: 'url', privateKey: 'k' });
+  const bal = await eth.getBalance('0x1');
+  expect(bal).toBe('5');
+});
+
+test('polygon connector sends tx', async () => {
+  const poly = polygonConnector({ rpcUrl: 'url', privateKey: 'k' });
+  const hash = await poly.sendTransaction('0x2', BigInt(1));
+  expect(hash).toBe('0xtx');
+});
+
+test('sendTransaction requires key', async () => {
+  const eth = ethereumConnector({ rpcUrl: 'url' });
+  await expect(eth.sendTransaction('0x2', BigInt(1))).rejects.toThrow(
+    'missing privateKey'
+  );
+});


### PR DESCRIPTION
## Summary
- implement Ethereum and Polygon connector helpers
- export connector registry and document blockchain usage
- provide example docs for blockchain connectors
- add Jest tests for blockchain connectors
- update task tracker and steps summary

## Testing
- `pnpm install` *(fails: domain not in allowlist)*
- `npx jest --runInBand` *(fails: preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717da6c5148331b994bb9cb018ef4f