### PR TITLE
Add graph database support

### DIFF
--- a/apps/orchestrator/src/index.test.ts
+++ b/apps/orchestrator/src/index.test.ts
@@ -124,6 +124,16 @@ test('createApp forwards language', async () => {
   expect(job.provider).toBe('aws');
 });
 
+test('createApp forwards database', async () => {
+  const res = await request(app)
+    .post('/api/createApp')
+    .set('x-tenant-id', 't1')
+    .send({ description: 'db', database: 'graph' });
+  expect(res.status).toBe(202);
+  const job = jobMem[Object.keys(jobMem)[0]];
+  expect(job.database).toBe('graph');
+});
+
 test('provider selection uses tenant table', async () => {
   tenantMem['t2'] = { id: 't2', provider: 'gcp' };
   const res = await request(app)

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -145,6 +145,7 @@ export interface Job {
   provider: 'aws' | 'gcp' | 'azure';
   description: string;
   language: string;
+  database?: string;
   status: 'queued' | 'running' | 'complete' | 'failed';
   created: number;
   previewUrl?: string;
@@ -208,6 +209,7 @@ export async function dispatchJob(job: Job) {
         jobId: job.id,
         description: job.description,
         language: job.language,
+        database: job.database,
         schema,
         provider: job.provider,
         plugins:
@@ -249,7 +251,7 @@ configureHealing(dispatchJob);
 app.post('/api/createApp', async (req, res) => {
   const tenantId = req.header(TENANT_HEADER);
   if (!tenantId) return res.status(401).json({ error: 'missing tenant' });
-  const { description, language = 'node', provider, preview } = req.body;
+  const { description, language = 'node', database, provider, preview } = req.body;
   if (!description)
     return res.status(400).json({ error: 'missing description' });
   const id = randomUUID();
@@ -261,6 +263,7 @@ app.post('/api/createApp', async (req, res) => {
     provider: prov,
     description,
     language,
+    database,
     status: 'queued',
     created: Date.now(),
   };
@@ -536,7 +539,7 @@ app.post('/api/testStream', async (req, res) => {
 app.post('/api/redeploy/:id', async (req, res) => {
   const tenantId = req.header(TENANT_HEADER);
   if (!tenantId) return res.status(401).json({ error: 'missing tenant' });
-  const { description, language = 'node', provider } = req.body;
+  const { description, language = 'node', database, provider } = req.body;
   if (!description)
     return res.status(400).json({ error: 'missing description' });
   const id = req.params.id;
@@ -548,6 +551,7 @@ app.post('/api/redeploy/:id', async (req, res) => {
     provider: prov,
     description,
     language,
+    database,
     status: 'queued',
     created: Date.now(),
   };

--- a/apps/portal/src/pages/create.tsx
+++ b/apps/portal/src/pages/create.tsx
@@ -4,6 +4,7 @@ export default function CreateApp() {
   const [description, setDescription] = useState('');
   const [jobId, setJobId] = useState('');
   const [language, setLanguage] = useState('node');
+  const [database, setDatabase] = useState('sql');
   const [listening, setListening] = useState(false);
   const recognitionRef = useRef<any>();
 
@@ -12,7 +13,7 @@ export default function CreateApp() {
     const res = await fetch('http://localhost:3002/api/createApp', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ description, language }),
+      body: JSON.stringify({ description, language, database }),
     });
     const data = await res.json();
     setJobId(data.jobId);
@@ -60,6 +61,18 @@ export default function CreateApp() {
               <option value="fastapi">FastAPI</option>
               <option value="go">Go</option>
               <option value="mobile">Mobile</option>
+            </select>
+          </label>
+        </div>
+        <div>
+          <label>
+            Database
+            <select
+              value={database}
+              onChange={(e) => setDatabase(e.target.value)}
+            >
+              <option value="sql">SQL</option>
+              <option value="graph">Graph</option>
             </select>
           </label>
         </div>

--- a/docs/graph-databases.md
+++ b/docs/graph-databases.md
@@ -1,0 +1,11 @@
+# Graph Databases
+
+The graph database template uses Neo4j by default and can be adapted for Amazon Neptune. Sample schema and CRUD routes are located under `packages/codegen-templates/src/templates/graph-db`.
+
+## Deployment
+
+1. Provision a Neo4j or Neptune instance and note the connection URL.
+2. Set `NEO4J_URL`, `NEO4J_USER` and `NEO4J_PASS` when running `server.ts`.
+3. For Neptune, adjust the connector to use `createNeptuneConnector` with the service endpoint.
+
+Graph databases are ideal for highly connected data but may require extra memory and compute resources.

--- a/packages/codegen-templates/src/templates/graph-db/README.md
+++ b/packages/codegen-templates/src/templates/graph-db/README.md
@@ -1,0 +1,5 @@
+# Graph Database Template
+
+This example demonstrates basic CRUD operations using a Neo4j graph database. It provides a sample schema and Express routes for creating and retrieving nodes.
+
+Set `NEO4J_URL`, `NEO4J_USER` and `NEO4J_PASS` environment variables before running `ts-node server.ts`.

--- a/packages/codegen-templates/src/templates/graph-db/schema.cypher
+++ b/packages/codegen-templates/src/templates/graph-db/schema.cypher
@@ -1,0 +1,8 @@
+// Sample schema for a simple social graph
+CREATE CONSTRAINT user_pk IF NOT EXISTS
+FOR (u:User)
+REQUIRE u.id IS UNIQUE;
+
+CREATE CONSTRAINT post_pk IF NOT EXISTS
+FOR (p:Post)
+REQUIRE p.id IS UNIQUE;

--- a/packages/codegen-templates/src/templates/graph-db/server.ts
+++ b/packages/codegen-templates/src/templates/graph-db/server.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+import { createNeo4jConnector } from '@iac/data-connectors/graph';
+
+const NEO4J_URL = process.env.NEO4J_URL || 'bolt://localhost:7687';
+const NEO4J_USER = process.env.NEO4J_USER || 'neo4j';
+const NEO4J_PASS = process.env.NEO4J_PASS || 'password';
+
+const db = createNeo4jConnector({ url: NEO4J_URL, user: NEO4J_USER, password: NEO4J_PASS });
+
+export const app = express();
+app.use(express.json());
+
+app.post('/users', async (req, res) => {
+  const { id, name } = req.body;
+  const [u] = await db.query('CREATE (u:User {id: $id, name: $name}) RETURN u', { id, name });
+  res.json(u);
+});
+
+app.get('/users/:id', async (req, res) => {
+  const [u] = await db.query('MATCH (u:User {id: $id}) RETURN u', { id: req.params.id });
+  res.json(u || null);
+});
+
+const port = Number(process.env.PORT || '4000');
+app.listen(port, () => console.log(`graph api listening on ${port}`));

--- a/packages/codegen-templates/src/templates/index.ts
+++ b/packages/codegen-templates/src/templates/index.ts
@@ -8,4 +8,5 @@ export const templates = [
   { name: 'go', description: 'Go REST API boilerplate' },
   { name: 'mobile', description: 'React Native starter app' },
   { name: 'ecommerce', description: 'React storefront with Stripe' },
+  { name: 'graph-db', description: 'Neo4j CRUD example' },
 ];

--- a/packages/data-connectors/package.json
+++ b/packages/data-connectors/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "kafkajs": "^2.2.4",
     "@aws-sdk/client-kinesis": "^3.841.0",
-    "ethers": "^6.6.2"
+    "ethers": "^6.6.2",
+    "neo4j-driver": "^5.11.0"
   }
 }

--- a/packages/data-connectors/src/graph.test.ts
+++ b/packages/data-connectors/src/graph.test.ts
@@ -1,0 +1,29 @@
+jest.mock('neo4j-driver', () => {
+  const run = jest.fn(async () => ({ records: [{ toObject: () => ({ id: 1 }) }] }));
+  const session = { run, close: jest.fn() };
+  const driver = { session: () => session, close: jest.fn() };
+  return {
+    default: {
+      driver: jest.fn(() => driver),
+      auth: { basic: jest.fn() },
+    },
+  };
+});
+
+jest.mock('node-fetch', () => jest.fn(async () => ({ ok: true, json: async () => ({ result: 'ok' }) })));
+import fetch from 'node-fetch';
+
+import { createNeo4jConnector, createNeptuneConnector } from './graph';
+
+test('neo4j connector runs query', async () => {
+  const db = createNeo4jConnector({ url: 'u', user: 'a', password: 'b' });
+  const res = await db.query('MATCH (n) RETURN n');
+  expect(res[0].id).toBe(1);
+});
+
+test('neptune connector posts query', async () => {
+  const db = createNeptuneConnector({ endpoint: 'http://n' });
+  const res = await db.query('g.V()');
+  expect(fetch).toHaveBeenCalled();
+  expect(res.result).toBe('ok');
+});

--- a/packages/data-connectors/src/graph.ts
+++ b/packages/data-connectors/src/graph.ts
@@ -1,0 +1,39 @@
+import fetch from 'node-fetch';
+import neo4j from 'neo4j-driver';
+
+export interface Neo4jOptions {
+  url: string;
+  user: string;
+  password: string;
+}
+
+export function createNeo4jConnector(opts: Neo4jOptions) {
+  const driver = neo4j.driver(opts.url, neo4j.auth.basic(opts.user, opts.password));
+  return {
+    async query(cypher: string, params: any = {}) {
+      const session = driver.session();
+      const result = await session.run(cypher, params);
+      await session.close();
+      return result.records.map(r => r.toObject());
+    },
+    close: () => driver.close()
+  };
+}
+
+export interface NeptuneOptions {
+  endpoint: string;
+}
+
+export function createNeptuneConnector(opts: NeptuneOptions) {
+  return {
+    async query(gremlin: string) {
+      const res = await fetch(`${opts.endpoint}/gremlin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ gremlin }),
+      });
+      if (!res.ok) throw new Error('Neptune query failed');
+      return res.json();
+    },
+  };
+}

--- a/packages/data-connectors/src/index.ts
+++ b/packages/data-connectors/src/index.ts
@@ -9,7 +9,9 @@ export * from './tfHelper';
 export * from './blockchain';
 export * from './kafka';
 export * from './kinesis';
+export * from './graph';
 import { ethereumConnector, polygonConnector } from './blockchain';
+import { createNeo4jConnector, createNeptuneConnector } from './graph';
 
 export async function stripeConnector(config: ConnectorConfig) {
   const res = await fetch('https://api.stripe.com/v1/charges', {
@@ -97,4 +99,6 @@ export const connectorRegistry = {
   google: googleConnector,
   ethereum: ethereumConnector,
   polygon: polygonConnector,
+  neo4j: createNeo4jConnector,
+  neptune: createNeptuneConnector,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       kafkajs:
         specifier: ^2.2.4
         version: 2.2.4
+      neo4j-driver:
+        specifier: ^5.11.0
+        version: 5.28.1
 
   packages/migrations: {}
 
@@ -266,6 +269,18 @@ importers:
         version: 4.21.2
 
   services/pricing:
+    dependencies:
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+
+  services/prompt-store:
+    dependencies:
+      express:
+        specifier: ^4.19.2
+        version: 4.21.2
+
+  services/query-optimizer:
     dependencies:
       express:
         specifier: ^4.18.2
@@ -1680,6 +1695,9 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -3034,6 +3052,15 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  neo4j-driver-bolt-connection@5.28.1:
+    resolution: {integrity: sha512-nY8GBhjOW7J0rDtpiyJn6kFdk2OiNVZZhZrO8//mwNXnf5VQJ6HqZQTDthH/9pEaX0Jvbastz1xU7ZL8xzqY0w==}
+
+  neo4j-driver-core@5.28.1:
+    resolution: {integrity: sha512-14vN8TlxC0JvJYfjWic5PwjsZ38loQLOKFTXwk4fWLTbCk6VhrhubB2Jsy9Rz+gM6PtTor4+6ClBEFDp1q/c8g==}
+
+  neo4j-driver@5.28.1:
+    resolution: {integrity: sha512-jbyBwyM0a3RLGcP43q3hIxPUPxA+1bE04RovOKdNAS42EtBMVCKcPSeOvWiHxgXp1ZFd0a8XqK+7LtguInOLUg==}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -3499,6 +3526,9 @@ packages:
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -6452,6 +6482,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -8130,6 +8165,20 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  neo4j-driver-bolt-connection@5.28.1:
+    dependencies:
+      buffer: 6.0.3
+      neo4j-driver-core: 5.28.1
+      string_decoder: 1.3.0
+
+  neo4j-driver-core@5.28.1: {}
+
+  neo4j-driver@5.28.1:
+    dependencies:
+      neo4j-driver-bolt-connection: 5.28.1
+      neo4j-driver-core: 5.28.1
+      rxjs: 7.8.2
+
   node-domexception@1.0.0: {}
 
   node-fetch@2.7.0:
@@ -8603,6 +8652,10 @@ snapshots:
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -438,3 +438,10 @@ This file records brief summaries of each pull request.
 - Updated connector registry and README documentation.
 - Created usage guide `docs/blockchain-connectors.md`.
 - Added Jest tests mocking `ethers` in `tests/blockchain`.
+
+## PR <pending> - Graph Database Templates
+
+- Added graph database codegen template with Neo4j CRUD example.
+- Implemented `createNeo4jConnector` and `createNeptuneConnector` in data connectors with tests.
+- Updated portal wizard to select database type and orchestrator to forward database info.
+- Documented usage in `docs/graph-databases.md` and updated task tracker for task 178.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -179,3 +179,4 @@
 | 175    | Prompt Versioning and Management           | Completed |
 | 176    | AI-Driven Query Optimization               | Completed |
 | 177    | Blockchain Connectors                      | Completed |
+| 178    | Graph Database Templates                   | Completed |


### PR DESCRIPTION
## Summary
- add graph database template with sample schema and CRUD server
- implement Neo4j and Neptune connectors
- expose database choice in portal wizard and orchestrator
- document graph database usage
- track task completion

## Testing
- `pnpm install --silent`
- `pnpm exec jest --runInBand` *(fails: Cannot read properties of undefined / SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6871890f50688331a03977aefc19fc19