### PR TITLE
Add edge deployment support

### DIFF
--- a/apps/orchestrator/src/README.md
+++ b/apps/orchestrator/src/README.md
@@ -15,8 +15,8 @@ node apps/orchestrator/src/index.ts
 - `POST /api/redeploy/:id` – submit a new description to redeploy an existing app.
 - `POST /api/publishMobile/:id` – package and submit the app to the mobile stores.
 
-Set `DEPLOY_URL`, `GCP_DEPLOY_URL` and `AZURE_DEPLOY_URL` to the deployment webhooks for each provider. `NOTIFY_EMAIL` enables job notifications.
+Set `DEPLOY_URL`, `GCP_DEPLOY_URL`, `AZURE_DEPLOY_URL` and `EDGE_DEPLOY_URL` to the deployment webhooks for each provider. `NOTIFY_EMAIL` enables job notifications.
 
 When `ARTIFACTS_BUCKET` is configured, generated code is uploaded to that S3 bucket after each job completes.
 
-Set `TENANTS_TABLE` to a DynamoDB table storing `{ id, provider }` for each tenant. Supported providers are `aws`, `azure` and `gcp`.
+Set `TENANTS_TABLE` to a DynamoDB table storing `{ id, provider }` for each tenant. Supported providers are `aws`, `azure`, `gcp` and `edge`.

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -68,6 +68,7 @@ const CODEGEN_URL = process.env.CODEGEN_URL || 'http://localhost:3003/generate';
 const DEPLOY_URL = process.env.DEPLOY_URL;
 const GCP_DEPLOY_URL = process.env.GCP_DEPLOY_URL;
 const AZURE_DEPLOY_URL = process.env.AZURE_DEPLOY_URL;
+const EDGE_DEPLOY_URL = process.env.EDGE_DEPLOY_URL;
 const NOTIFY_EMAIL = process.env.NOTIFY_EMAIL;
 const ARTIFACTS_BUCKET = process.env.ARTIFACTS_BUCKET;
 const TENANT_HEADER = 'x-tenant-id';
@@ -146,17 +147,19 @@ async function chatCompletion(message: string): Promise<string> {
   }
 }
 
-async function getProvider(tenantId: string): Promise<'aws' | 'azure' | 'gcp'> {
+async function getProvider(
+  tenantId: string
+): Promise<'aws' | 'azure' | 'gcp' | 'edge'> {
   const cfg = await getItem<{ id: string; provider?: string }>(TENANTS_TABLE, {
     id: tenantId,
   });
-  return (cfg?.provider as 'aws' | 'azure' | 'gcp') || 'aws';
+  return (cfg?.provider as 'aws' | 'azure' | 'gcp' | 'edge') || 'aws';
 }
 
 export interface Job {
   id: string;
   tenantId: string;
-  provider: 'aws' | 'gcp' | 'azure';
+  provider: 'aws' | 'gcp' | 'azure' | 'edge';
   description: string;
   language: string;
   database?: string;
@@ -171,6 +174,7 @@ async function triggerDeploy(jobId: string, provider: string) {
   if (provider === 'aws') url = DEPLOY_URL;
   if (provider === 'gcp') url = GCP_DEPLOY_URL;
   if (provider === 'azure') url = AZURE_DEPLOY_URL;
+  if (provider === 'edge') url = EDGE_DEPLOY_URL;
   if (!url) {
     console.log('deploy url not configured for provider', provider);
     return;
@@ -306,7 +310,7 @@ app.post('/api/createApp', async (req, res) => {
   if (!description)
     return res.status(400).json({ error: 'missing description' });
   const id = randomUUID();
-  const prov: 'aws' | 'gcp' | 'azure' =
+  const prov: 'aws' | 'gcp' | 'azure' | 'edge' =
     provider || (await getProvider(tenantId));
   const job: Job = {
     id,
@@ -594,7 +598,7 @@ app.post('/api/redeploy/:id', async (req, res) => {
   if (!description)
     return res.status(400).json({ error: 'missing description' });
   const id = req.params.id;
-  const prov: 'aws' | 'gcp' | 'azure' =
+  const prov: 'aws' | 'gcp' | 'azure' | 'edge' =
     provider || (await getProvider(tenantId));
   const job: Job = {
     id,

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This folder contains user guides and architecture diagrams.
 - [Voice Guided Modeling](./voice-modeling.md)
 - [Edge Connectors](./edge-connectors.md)
 - [Edge Inference](./edge-inference.md)
+- [Edge Deployments](./edge-deployments.md)
 - [A/B Testing](./ab-testing-toolkit.md)
 - [VR Preview](./vr-preview.md)
 - [AR Preview](./ar-preview.md)

--- a/docs/edge-deployments.md
+++ b/docs/edge-deployments.md
@@ -1,0 +1,17 @@
+# Edge Deployments
+
+This guide explains how to deploy generated applications to edge networks using Cloudflare Workers or AWS Lambda@Edge.
+
+## Setup
+
+1. Configure the Terraform module under `infrastructure/edge` for your desired provider.
+2. Set the `EDGE_DEPLOY_URL` environment variable in the orchestrator to trigger deployments.
+3. Select `edge` as the provider when creating a new app:
+
+```bash
+curl -X POST http://localhost:3002/api/createApp \
+  -H "x-tenant-id: demo" \
+  -d '{"description":"edge demo","provider":"edge"}'
+```
+
+The orchestrator will dispatch the job and deploy the result to the configured edge platform.

--- a/infrastructure/edge/README.md
+++ b/infrastructure/edge/README.md
@@ -1,0 +1,21 @@
+# Edge Deployment Modules
+
+This folder contains optional Terraform modules for deploying applications to edge networks like Cloudflare Workers and AWS Lambda@Edge.
+
+## Usage
+
+```hcl
+module "edge" {
+  source               = "./infrastructure/edge"
+  cloudflare_account   = var.cloudflare_account
+  cloudflare_zone      = var.cloudflare_zone
+  lambda_function_arn  = var.lambda_function_arn
+}
+```
+
+Initialize and format the module with:
+
+```bash
+terraform init
+terraform fmt
+```

--- a/infrastructure/edge/main.tf
+++ b/infrastructure/edge/main.tf
@@ -1,0 +1,52 @@
+# Cloudflare Worker deployment
+provider "cloudflare" {
+  account_id = var.cloudflare_account
+}
+
+data "cloudflare_zone" "zone" {
+  name = var.cloudflare_zone
+}
+
+resource "cloudflare_worker_script" "edge" {
+  name    = var.worker_name
+  content = file(var.worker_script)
+}
+
+resource "cloudflare_worker_route" "route" {
+  zone_id     = data.cloudflare_zone.zone.id
+  pattern     = var.worker_route
+  script_name = cloudflare_worker_script.edge.name
+}
+
+# AWS Lambda@Edge deployment
+resource "aws_lambda_function" "edge" {
+  filename      = var.lambda_package
+  function_name = var.lambda_function_name
+  handler       = var.lambda_handler
+  runtime       = var.lambda_runtime
+  publish       = true
+  role          = var.lambda_role
+}
+
+resource "aws_cloudfront_distribution" "edge" {
+  enabled = true
+
+  origin {
+    domain_name = var.s3_origin_domain
+    origin_id   = "edge-origin"
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "edge-origin"
+    viewer_protocol_policy = "redirect-to-https"
+    lambda_function_association {
+      event_type   = "viewer-request"
+      lambda_arn   = aws_lambda_function.edge.qualified_arn
+      include_body = false
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/infrastructure/edge/outputs.tf
+++ b/infrastructure/edge/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudflare_worker" {
+  description = "Deployed Cloudflare worker name"
+  value       = cloudflare_worker_script.edge.name
+}
+
+output "cloudfront_distribution" {
+  description = "ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.edge.id
+}

--- a/infrastructure/edge/variables.tf
+++ b/infrastructure/edge/variables.tf
@@ -1,0 +1,54 @@
+variable "cloudflare_account" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone" {
+  description = "DNS zone for Cloudflare"
+  type        = string
+}
+
+variable "worker_name" {
+  description = "Name of the worker script"
+  type        = string
+}
+
+variable "worker_script" {
+  description = "Path to the Cloudflare worker script"
+  type        = string
+}
+
+variable "worker_route" {
+  description = "Route pattern for the worker"
+  type        = string
+}
+
+variable "lambda_package" {
+  description = "Path to Lambda@Edge zip package"
+  type        = string
+}
+
+variable "lambda_function_name" {
+  description = "Name of the Lambda@Edge function"
+  type        = string
+}
+
+variable "lambda_handler" {
+  description = "Handler for the Lambda@Edge function"
+  type        = string
+}
+
+variable "lambda_runtime" {
+  description = "Runtime for the Lambda@Edge function"
+  type        = string
+}
+
+variable "lambda_role" {
+  description = "IAM role for the Lambda function"
+  type        = string
+}
+
+variable "s3_origin_domain" {
+  description = "Domain of the S3 bucket origin"
+  type        = string
+}

--- a/packages/codegen-templates/src/templates/edge/README.md
+++ b/packages/codegen-templates/src/templates/edge/README.md
@@ -1,0 +1,3 @@
+# Edge Function Template
+
+Basic starter for deploying a Cloudflare Worker or Lambda@Edge function.

--- a/packages/codegen-templates/src/templates/edge/worker.ts
+++ b/packages/codegen-templates/src/templates/edge/worker.ts
@@ -1,0 +1,3 @@
+addEventListener('fetch', (event) => {
+  event.respondWith(new Response('hello from the edge'));
+});

--- a/packages/codegen-templates/src/templates/index.ts
+++ b/packages/codegen-templates/src/templates/index.ts
@@ -9,4 +9,5 @@ export const templates = [
   { name: 'mobile', description: 'React Native starter app' },
   { name: 'ecommerce', description: 'React storefront with Stripe' },
   { name: 'graph-db', description: 'Neo4j CRUD example' },
+  { name: 'edge', description: 'Cloudflare Worker starter' },
 ];

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -458,3 +458,4 @@ This file records brief summaries of each pull request.
 - Integrated tracing into orchestrator and analytics services.
 - Provisioned optional collector in `infrastructure/observability`.
 - Documented trace viewing instructions and updated task tracker for task 181.
+\n## PR <pending> - Edge Deployment & CDN Integration\n- Added Terraform module `infrastructure/edge` with Cloudflare and Lambda@Edge resources.\n- Added edge provider option in orchestrator with `EDGE_DEPLOY_URL`.\n- Created edge codegen template and updated templates index.\n- Documented usage in `docs/edge-deployments.md` and marked task 182 complete.\n

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -183,3 +183,4 @@
 | 179    | Multi-Region Disaster Recovery           | Completed |
 | 180    | AI-Driven Code Review Service            | Completed |
 | 181    | OpenTelemetry Tracing                     | Completed |
+| 182    | Edge Deployment & CDN Integration          | Completed |


### PR DESCRIPTION
## Summary
- add `infrastructure/edge` Terraform module for Cloudflare and Lambda@Edge
- allow orchestrator to dispatch `edge` provider jobs
- create edge codegen template and update template index
- document setup in `docs/edge-deployments.md`
- mark task 182 as complete and log summary

## Testing
- `terraform fmt -recursive`
- `pnpm install`
- `pnpm test` *(fails: collab-workflow-service build error)*

------
https://chatgpt.com/codex/tasks/task_e_6871b0be633c83318e36a3d8cfa7c44d