### PR TITLE
Implement collaborative AR sessions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ This folder contains user guides and architecture diagrams.
 - [A/B Testing](./ab-testing-toolkit.md)
 - [VR Preview](./vr-preview.md)
 - [AR Preview](./ar-preview.md)
+- [Collaborative AR Sessions](./collaborative-ar.md)
 - [Template Marketplace](./template-marketplace.md)
 - [Pair Programmer Chat](./pair-programmer.md)
 - [Blockchain Connectors](./blockchain-connectors.md)

--- a/docs/collaborative-ar.md
+++ b/docs/collaborative-ar.md
@@ -1,0 +1,11 @@
+# Collaborative AR Sessions
+
+Multiple users can join the `/ar` preview page and edit layouts together. The portal connects to the orchestrator's WebRTC signaling endpoint and opens peer connections between participants.
+
+Layout changes are transmitted over a data channel so each device updates in real time. The orchestrator forwards signaling messages and records session events via the analytics service for replay.
+
+## Setup
+
+1. Start the analytics service and orchestrator.
+2. Open `/ar` in several browser windows. Each client will automatically join the default session.
+3. Move objects in one window to see them appear in all others.

--- a/services/analytics/src/index.test.ts
+++ b/services/analytics/src/index.test.ts
@@ -66,3 +66,14 @@ test('business tips endpoint returns tips', async () => {
     )
   ).toBe(true);
 });
+
+test('stores and retrieves AR session events', async () => {
+  await request(app)
+    .post('/arSessions/s1')
+    .send({ action: 'add', item: { x: 1 } });
+  const res = await request(app).get('/arSessions/s1');
+  expect(res.status).toBe(200);
+  expect(res.body.events[0].item.x).toBe(1);
+  const list = await request(app).get('/arSessions');
+  expect(list.body.sessions).toContain('s1');
+});

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -479,3 +479,9 @@ This file records brief summaries of each pull request.
 - Implemented `/api/seedData/:id` in the orchestrator saving output to `seeds/`.
 - Created portal page `seed-data.tsx` to request generation.
 - Documented usage in `docs/automatic-data-seeding.md` and marked tasks 183-184 complete.
+
+## PR <pending> - Collaborative AR Sessions
+- Added WebRTC signaling WebSocket `/arSignal` in orchestrator and persistence hooks in analytics.
+- Extended analytics API with `/arSessions` endpoints and tests.
+- Updated AR preview page to sync layout changes via peer connections.
+- Documented setup in `docs/collaborative-ar.md` and marked task 185 complete.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -187,3 +187,4 @@
 
 | 183    | AI ChatOps Assistant                        | Completed |
 | 184    | AI-Generated Seed Data                      | Completed |
+| 185    | Collaborative AR Sessions                   | Completed |


### PR DESCRIPTION
## Summary
- add AR session persistence endpoints in analytics service
- support signaling server `/arSignal` in orchestrator
- enhance AR preview page to sync layout via WebRTC data channels
- document setup for collaborative AR
- update task tracker and steps summary

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6872b1f10f64833180df0150b467bb90