### PR TITLE
feat: export prompt experiment results

### DIFF
--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -586,6 +586,21 @@ app.get('/api/experiments/:id', async (req, res) => {
   }
 });
 
+app.get('/api/experiments/:id/export', async (req, res) => {
+  try {
+    const response = await fetch(
+      `${PROMPT_EXP_URL}/experiments/${encodeURIComponent(req.params.id)}/export`
+    );
+    const text = await response.text();
+    res
+      .status(response.status)
+      .set('Content-Type', response.headers.get('content-type') || 'text/plain')
+      .send(text);
+  } catch {
+    res.status(500).json({ error: 'service unavailable' });
+  }
+});
+
 app.put('/api/experiments/:id', async (req, res) => {
   try {
     const response = await fetch(
@@ -892,7 +907,12 @@ app.post('/api/edgeScaling', async (req, res) => {
   if (!functionName || !version)
     return res.status(400).json({ error: 'missing params' });
   try {
-    await updateEdgeScaling(functionName, version, Number(min || 1), Number(max || 10));
+    await updateEdgeScaling(
+      functionName,
+      version,
+      Number(min || 1),
+      Number(max || 10)
+    );
     res.status(201).json({ ok: true });
   } catch (err) {
     console.error('edge scaling failed', err);

--- a/apps/portal/src/pages/experiments.tsx
+++ b/apps/portal/src/pages/experiments.tsx
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 
-const fetcher = (u: string) => fetch(u).then(r => r.json());
+const fetcher = (u: string) => fetch(u).then((r) => r.json());
 
 export default function Experiments() {
   const { data } = useSWR('/api/experiments', fetcher);
@@ -8,9 +8,13 @@ export default function Experiments() {
     <div style={{ padding: 20 }}>
       <h1>Experiments</h1>
       <ul>
-        {data && data.map((e: any) => (
-          <li key={e.id}>{e.name}: {e.winner}</li>
-        ))}
+        {data &&
+          data.map((e: any) => (
+            <li key={e.id}>
+              {e.name}: {e.winner}{' '}
+              <a href={`/api/experiments/${e.id}/export`}>Export</a>
+            </li>
+          ))}
       </ul>
     </div>
   );

--- a/apps/portal/src/pages/prompt-tests.tsx
+++ b/apps/portal/src/pages/prompt-tests.tsx
@@ -15,7 +15,10 @@ export default function PromptTests() {
     await fetch('/api/experiments', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, variants: { A: { prompt: a }, B: { prompt: b } } }),
+      body: JSON.stringify({
+        name,
+        variants: { A: { prompt: a }, B: { prompt: b } },
+      }),
     });
     setName('');
     setA('');
@@ -38,7 +41,11 @@ export default function PromptTests() {
     <div style={{ padding: 20 }}>
       <h1>Prompt Experiments</h1>
       <div style={{ marginBottom: 10 }}>
-        <input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <input
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
         <input
           placeholder="Variant A"
           value={a}
@@ -61,13 +68,17 @@ export default function PromptTests() {
           {exp.winner && <span>(winner: {exp.winner})</span>}
           <div>
             <button onClick={() => record(exp.id, 'A', true)}>A Success</button>
-            <button onClick={() => record(exp.id, 'B', true)} style={{ marginLeft: 4 }}>
+            <button
+              onClick={() => record(exp.id, 'B', true)}
+              style={{ marginLeft: 4 }}
+            >
               B Success
             </button>
           </div>
           <pre style={{ background: '#f0f0f0', padding: 10 }}>
             {JSON.stringify(exp.variants, null, 2)}
           </pre>
+          <a href={`/api/experiments/${exp.id}/export`}>Export CSV</a>
         </div>
       ))}
     </div>

--- a/docs/prompt-ab-testing.md
+++ b/docs/prompt-ab-testing.md
@@ -7,3 +7,4 @@ The prompt experiments service allows comparing multiple prompt variants and col
 1. Start the service with `pnpm --filter prompt-experiments build && node services/prompt-experiments/dist/index.js`.
 2. Use the orchestrator endpoints `/api/experiments` to create, update and retrieve experiments.
 3. Visit `/prompt-tests` in the portal to launch tests and monitor results.
+4. Download CSV results from `/api/experiments/:id/export` for further analysis.

--- a/services/prompt-experiments/README.md
+++ b/services/prompt-experiments/README.md
@@ -8,6 +8,7 @@ This service manages prompt A/B tests and metrics.
 - `POST /experiments` – create or update an experiment
 - `GET /experiments/:id` – fetch a single experiment
 - `GET /experiments/:id/summary` – get success rates and best variant
+- `GET /experiments/:id/export` – download results as CSV
 - `PUT /experiments/:id` – update metrics or winner
 - `DELETE /experiments/:id` – remove an experiment
 

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -558,7 +558,6 @@ This file records brief summaries of each pull request.
 - Exposed orchestrator endpoint `/api/edgeScaling` to adjust scaling settings.
 - Documented the feature in `docs/edge-auto-scaling.md` and marked task 194 complete.
 
-
 ## PR <pending> - Prompt A/B Testing Platform
 
 - Added new `prompt-experiments` service with CRUD endpoints and tests.
@@ -571,3 +570,9 @@ This file records brief summaries of each pull request.
 - Sanitized input fields in the `prompt-experiments` service.
 - Added `/experiments/:id/summary` endpoint returning success rates.
 - Extended tests and README documentation for the new behavior.
+
+## PR <pending> - Prompt Experiments Export
+
+- Added CSV export functionality via `/experiments/:id/export` in `prompt-experiments`.
+- Proxied export route through the orchestrator and exposed download links in portal pages.
+- Documented the workflow and extended tests to validate CSV output.


### PR DESCRIPTION
## Summary
- add CSV export endpoint to prompt experiments service
- proxy export route through orchestrator and expose portal download links
- document export workflow and cover with tests

## Testing
- `pnpm exec jest services/prompt-experiments/src/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688e964f59688331ac7648af6c925f9f