### PR TITLE
feat: add recursive sanitization helper

### DIFF
--- a/packages/shared/src/README.md
+++ b/packages/shared/src/README.md
@@ -29,6 +29,9 @@ This package now includes DynamoDB helper functions built on the AWS SDK v3 `Dyn
 
 `sanitize(str)` HTML-escapes user supplied strings to prevent injection attacks.
 
+`sanitizeObject(value)` recursively escapes all string fields within objects or
+arrays, returning a sanitized copy. Useful for cleaning complex payloads.
+
 ## Audit Logging
 
 `logAudit(msg)` appends a timestamped entry to `AUDIT_LOG` (default `audit.log`).

--- a/packages/shared/src/sanitize.test.ts
+++ b/packages/shared/src/sanitize.test.ts
@@ -1,5 +1,16 @@
-import { sanitize } from './sanitize';
+import { sanitize, sanitizeObject } from './sanitize';
 
 test('escapes html', () => {
   expect(sanitize('<script>')).toBe('&lt;script&gt;');
+});
+
+test('sanitizes objects and arrays', () => {
+  const input = {
+    comment: '<b>Hello</b>',
+    items: ['<img src=x>', { note: '<script>alert(1)</script>' }],
+  };
+  const result = sanitizeObject(input);
+  expect(result.comment).toBe('&lt;b&gt;Hello&lt;&#x2F;b&gt;');
+  expect(result.items[0]).toBe('&lt;img src=x&gt;');
+  expect(result.items[1].note).toBe('&lt;script&gt;alert(1)&lt;&#x2F;script&gt;');
 });

--- a/packages/shared/src/sanitize.ts
+++ b/packages/shared/src/sanitize.ts
@@ -1,5 +1,30 @@
 import { escape } from 'validator';
 
+/**
+ * HTML-escapes a string to guard against injection attacks.
+ */
 export function sanitize(input: string): string {
   return escape(input);
+}
+
+/**
+ * Recursively sanitizes all string fields within an object or array.
+ * Non-string values are returned as-is. Useful for cleaning user supplied
+ * payloads before persistence.
+ */
+export function sanitizeObject<T>(value: T): T {
+  if (typeof value === 'string') {
+    return sanitize(value) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => sanitizeObject(v)) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const result: any = {};
+    for (const [key, val] of Object.entries(value as any)) {
+      result[key] = sanitizeObject(val);
+    }
+    return result;
+  }
+  return value;
 }

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -576,3 +576,9 @@ This file records brief summaries of each pull request.
 - Added CSV export functionality via `/experiments/:id/export` in `prompt-experiments`.
 - Proxied export route through the orchestrator and exposed download links in portal pages.
 - Documented the workflow and extended tests to validate CSV output.
+
+## PR <pending> - Recursive sanitization utility
+
+- Added `sanitizeObject` helper in `packages/shared` to deeply escape all string fields.
+- Extended sanitization tests to cover nested objects and arrays.
+- Documented the new helper in `packages/shared/src/README.md`.


### PR DESCRIPTION
## Summary
- add `sanitizeObject` to recursively escape strings within objects or arrays
- cover nested sanitization with new jest tests
- document deep sanitization helper in shared package README

## Testing
- `npx jest packages/shared/src/sanitize.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688ea5334dfc8331892646534c53afe0