### PR TITLE
feat: add exponential backoff to retry helper

### DIFF
--- a/packages/retry/README.md
+++ b/packages/retry/README.md
@@ -1,3 +1,3 @@
 # retry package
 
-Utility to automatically retry failed asynchronous tasks a configurable number of times.
+Utility to automatically retry failed asynchronous tasks a configurable number of times with optional exponential backoff.

--- a/packages/retry/src/README.md
+++ b/packages/retry/src/README.md
@@ -5,5 +5,6 @@ This package provides a simple async `retry` function used to repeat failed task
 ```
 import { retry } from 'retry';
 
-await retry(() => doSomething(), 5, 1000);
+// retry up to 5 times with exponential backoff (1000ms, then 2000ms, ...)
+await retry(() => doSomething(), 5, 1000, 2);
 ```

--- a/packages/retry/src/index.test.ts
+++ b/packages/retry/src/index.test.ts
@@ -10,3 +10,26 @@ test('retries until success', async () => {
   expect(result).toBe('ok');
   expect(count).toBe(2);
 });
+
+test('applies exponential backoff', async () => {
+  const delays: number[] = [];
+  const original = setTimeout;
+  // Capture requested delays while executing callbacks immediately
+  global.setTimeout = ((fn: (...args: any[]) => void, ms?: number, ...args: any[]) => {
+    delays.push(ms || 0);
+    return original(fn as any, 0, ...args) as unknown as NodeJS.Timeout;
+  }) as typeof setTimeout;
+
+  let attempts = 0;
+  const result = await retry(async () => {
+    attempts++;
+    if (attempts < 3) throw new Error('fail');
+    return 'ok';
+  }, 3, 100, 2);
+
+  expect(result).toBe('ok');
+  expect(attempts).toBe(3);
+  expect(delays).toEqual([100, 200]);
+
+  global.setTimeout = original;
+});

--- a/packages/retry/src/index.ts
+++ b/packages/retry/src/index.ts
@@ -1,4 +1,17 @@
-export async function retry<T>(fn: () => Promise<T>, attempts = 3, delayMs = 500): Promise<T> {
+/**
+ * Retry a promise-returning function a specified number of times.
+ *
+ * @param fn       Function to invoke.
+ * @param attempts Number of attempts before failing.
+ * @param delayMs  Initial delay between attempts in milliseconds.
+ * @param factor   Multiplier used for exponential backoff. Defaults to `1` (no backoff).
+ */
+export async function retry<T>(
+  fn: () => Promise<T>,
+  attempts = 3,
+  delayMs = 500,
+  factor = 1
+): Promise<T> {
   let lastError: unknown;
   for (let i = 0; i < attempts; i++) {
     try {
@@ -6,7 +19,8 @@ export async function retry<T>(fn: () => Promise<T>, attempts = 3, delayMs = 500
     } catch (err) {
       lastError = err;
       if (i < attempts - 1) {
-        await new Promise(res => setTimeout(res, delayMs));
+        const backoff = delayMs * Math.pow(factor, i);
+        await new Promise(res => setTimeout(res, backoff));
       }
     }
   }

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -582,3 +582,8 @@ This file records brief summaries of each pull request.
 - Added `sanitizeObject` helper in `packages/shared` to deeply escape all string fields.
 - Extended sanitization tests to cover nested objects and arrays.
 - Documented the new helper in `packages/shared/src/README.md`.
+
+## PR <pending> - Retry exponential backoff
+
+- Extended `packages/retry` to support exponential backoff via a `factor` parameter.
+- Added unit tests validating delay growth and updated README usage examples.


### PR DESCRIPTION
## Summary
- support exponential backoff in retry helper via new `factor` option
- document usage with backoff examples
- add unit tests verifying delay growth

## Testing
- `pnpm --filter retry lint`
- `npx jest packages/retry/src/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688eb4d8bd548331a92c7136fa45297e