### PR TITLE
feat: add variant creation for prompt experiments

### DIFF
--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -574,6 +574,23 @@ app.post('/api/experiments', async (req, res) => {
   }
 });
 
+app.post('/api/experiments/:id/variants', async (req, res) => {
+  try {
+    const response = await fetch(
+      `${PROMPT_EXP_URL}/experiments/${encodeURIComponent(req.params.id)}/variants`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req.body),
+      }
+    );
+    const json = await response.json();
+    res.status(response.status).json(json);
+  } catch {
+    res.status(500).json({ error: 'service unavailable' });
+  }
+});
+
 app.get('/api/experiments/:id', async (req, res) => {
   try {
     const response = await fetch(

--- a/apps/portal/src/pages/prompt-tests.tsx
+++ b/apps/portal/src/pages/prompt-tests.tsx
@@ -78,9 +78,45 @@ export default function PromptTests() {
           <pre style={{ background: '#f0f0f0', padding: 10 }}>
             {JSON.stringify(exp.variants, null, 2)}
           </pre>
+          <VariantAdder id={exp.id} mutate={mutate} />
           <a href={`/api/experiments/${exp.id}/export`}>Export CSV</a>
         </div>
       ))}
+    </div>
+  );
+}
+
+function VariantAdder({ id, mutate }: { id: string; mutate: () => void }) {
+  const [name, setName] = useState('');
+  const [prompt, setPrompt] = useState('');
+
+  const add = async () => {
+    await fetch(`/api/experiments/${id}/variants`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, prompt }),
+    });
+    setName('');
+    setPrompt('');
+    mutate();
+  };
+
+  return (
+    <div style={{ marginTop: 4 }}>
+      <input
+        placeholder="Variant name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        placeholder="Prompt"
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        style={{ marginLeft: 4 }}
+      />
+      <button onClick={add} style={{ marginLeft: 4 }}>
+        Add Variant
+      </button>
     </div>
   );
 }

--- a/docs/prompt-ab-testing.md
+++ b/docs/prompt-ab-testing.md
@@ -5,6 +5,6 @@ The prompt experiments service allows comparing multiple prompt variants and col
 ## Usage
 
 1. Start the service with `pnpm --filter prompt-experiments build && node services/prompt-experiments/dist/index.js`.
-2. Use the orchestrator endpoints `/api/experiments` to create, update and retrieve experiments. When recording results or setting a winner via `PUT /api/experiments/:id`, provide variant and winner names that exist on the experiment; otherwise a `400` error is returned.
-3. Visit `/prompt-tests` in the portal to launch tests and monitor results.
+2. Use the orchestrator endpoints `/api/experiments` to create experiments and `/api/experiments/:id/variants` to add variants. When recording results or setting a winner via `PUT /api/experiments/:id`, provide variant and winner names that exist on the experiment; otherwise a `400` error is returned.
+3. Visit `/prompt-tests` in the portal to launch tests, add variants and monitor results.
 4. Download CSV results from `/api/experiments/:id/export` for further analysis.

--- a/services/prompt-experiments/README.md
+++ b/services/prompt-experiments/README.md
@@ -5,7 +5,8 @@ This service manages prompt A/B tests and metrics.
 ## Endpoints
 
 - `GET /experiments` – list all experiments
-- `POST /experiments` – create or update an experiment
+- `POST /experiments` – create a new experiment
+- `POST /experiments/:id/variants` – add a variant
 - `GET /experiments/:id` – fetch a single experiment
 - `GET /experiments/:id/summary` – get success rates and best variant
 - `GET /experiments/:id/export` – download results as CSV

--- a/services/prompt-experiments/src/index.ts
+++ b/services/prompt-experiments/src/index.ts
@@ -111,6 +111,31 @@ app.post('/experiments', (req, res) => {
   res.status(201).json(record);
 });
 
+app.post('/experiments/:id/variants', (req, res) => {
+  const { name, prompt } = req.body as {
+    name?: string;
+    prompt?: string;
+  };
+  if (!name || !prompt)
+    return res.status(400).json({ error: 'missing fields' });
+
+  const list = read();
+  const exp = find(req.params.id, list);
+  if (!exp) return res.status(404).json({ error: 'not found' });
+
+  const cleanName = sanitize(name);
+  if (exp.variants[cleanName])
+    return res.status(400).json({ error: 'variant exists' });
+
+  exp.variants[cleanName] = {
+    prompt: sanitize(prompt),
+    success: 0,
+    total: 0,
+  };
+  save(list);
+  res.status(201).json(exp.variants[cleanName]);
+});
+
 app.get('/experiments/:id', (req, res) => {
   const exp = find(req.params.id, read());
   if (!exp) return res.status(404).json({ error: 'not found' });

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -593,3 +593,8 @@ This file records brief summaries of each pull request.
 - Enforced variant and winner validation in `services/prompt-experiments` update endpoint.
 - Added unit tests for invalid variant and winner scenarios.
 - Documented validation rules in service README and prompt A/B testing guide.
+
+## PR <pending> - Add experiment variant creation
+
+- Added `/experiments/:id/variants` endpoint with sanitization and duplicate checks in `services/prompt-experiments`.
+- Updated orchestrator proxy, portal page, and documentation to support adding variants.


### PR DESCRIPTION
## Summary
- allow adding sanitized variants to prompt experiments
- proxy new endpoint through orchestrator and expose variant form in portal
- document variant workflow and tests

## Testing
- `npx jest services/prompt-experiments/src/index.test.ts apps/orchestrator/src/index.test.ts` *(fails: connectors DELETE removes type; chat websocket responds; arSignal broadcasts messages; publishMobile triggers store calls; arLayout endpoints store and retrieve layout; modelUpdate forwards to federated service; syntheticData forwards to service; exportData anonymizes PII fields; seedData endpoint writes seed file; community models endpoints)*
- `pnpm --filter prompt-experiments lint`
- `pnpm --filter orchestrator lint`
- `pnpm --filter portal lint`


------
https://chatgpt.com/codex/tasks/task_e_689400bcf5a0833184d1e28e6781af4e