### PR TITLE
Add experiments summary API and portal integration

### DIFF
--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -560,6 +560,16 @@ app.get('/api/experiments', async (_req, res) => {
   }
 });
 
+app.get('/api/experiments/summary', async (_req, res) => {
+  try {
+    const response = await fetch(`${PROMPT_EXP_URL}/experiments/summary`);
+    const json = await response.json();
+    res.status(response.status).json(json);
+  } catch {
+    res.status(500).json({ error: 'service unavailable' });
+  }
+});
+
 app.post('/api/experiments', async (req, res) => {
   try {
     const response = await fetch(`${PROMPT_EXP_URL}/experiments`, {

--- a/apps/portal/src/pages/experiments.tsx
+++ b/apps/portal/src/pages/experiments.tsx
@@ -3,7 +3,7 @@ import useSWR from 'swr';
 const fetcher = (u: string) => fetch(u).then((r) => r.json());
 
 export default function Experiments() {
-  const { data } = useSWR('/api/experiments', fetcher);
+  const { data } = useSWR('/api/experiments/summary', fetcher);
   return (
     <div style={{ padding: 20 }}>
       <h1>Experiments</h1>
@@ -11,7 +11,7 @@ export default function Experiments() {
         {data &&
           data.map((e: any) => (
             <li key={e.id}>
-              {e.name}: {e.winner}{' '}
+              {e.name}: best {e.best} {e.winner && `(winner: ${e.winner})`}{' '}
               <a href={`/api/experiments/${e.id}/export`}>Export</a>
             </li>
           ))}

--- a/docs/prompt-ab-testing.md
+++ b/docs/prompt-ab-testing.md
@@ -6,5 +6,6 @@ The prompt experiments service allows comparing multiple prompt variants and col
 
 1. Start the service with `pnpm --filter prompt-experiments build && node services/prompt-experiments/dist/index.js`.
 2. Use the orchestrator endpoints `/api/experiments` to create experiments and `/api/experiments/:id/variants` to add variants. When recording results or setting a winner via `PUT /api/experiments/:id`, provide variant and winner names that exist on the experiment; otherwise a `400` error is returned.
-3. Visit `/prompt-tests` in the portal to launch tests, add variants and monitor results.
-4. Download CSV results from `/api/experiments/:id/export` for further analysis.
+3. Retrieve aggregated success rates with `/api/experiments/summary`.
+4. Visit `/prompt-tests` in the portal to launch tests, add variants and monitor results.
+5. Download CSV results from `/api/experiments/:id/export` for further analysis.

--- a/services/prompt-experiments/README.md
+++ b/services/prompt-experiments/README.md
@@ -5,6 +5,7 @@ This service manages prompt A/B tests and metrics.
 ## Endpoints
 
 - `GET /experiments` – list all experiments
+- `GET /experiments/summary` – list summaries with success rates
 - `POST /experiments` – create a new experiment
 - `POST /experiments/:id/variants` – add a variant
 - `GET /experiments/:id` – fetch a single experiment

--- a/services/prompt-experiments/src/index.test.ts
+++ b/services/prompt-experiments/src/index.test.ts
@@ -90,3 +90,19 @@ test('adds new variants with sanitization', async () => {
     .send({ name: 'B', prompt: 'other' });
   expect(dup.status).toBe(400);
 });
+
+test('returns summaries for all experiments', async () => {
+  const create = await request(app)
+    .post('/experiments')
+    .send({ name: 'sum', variants: { A: { prompt: 'a' } } });
+  const id = create.body.id;
+  await request(app)
+    .put(`/experiments/${id}`)
+    .send({ variant: 'A', success: true });
+
+  const summaries = await request(app).get('/experiments/summary');
+  expect(summaries.status).toBe(200);
+  expect(summaries.body).toHaveLength(1);
+  expect(summaries.body[0].best).toBe('A');
+  expect(summaries.body[0].variants.A.rate).toBe(1);
+});

--- a/services/prompt-experiments/src/index.ts
+++ b/services/prompt-experiments/src/index.ts
@@ -87,6 +87,11 @@ app.get('/experiments', (_req, res) => {
   res.json(read());
 });
 
+app.get('/experiments/summary', (_req, res) => {
+  const list = read().map(summarize);
+  res.json(list);
+});
+
 app.post('/experiments', (req, res) => {
   const { name, variants } = req.body as {
     name?: string;

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -598,3 +598,9 @@ This file records brief summaries of each pull request.
 
 - Added `/experiments/:id/variants` endpoint with sanitization and duplicate checks in `services/prompt-experiments`.
 - Updated orchestrator proxy, portal page, and documentation to support adding variants.
+
+## PR <pending> - Experiment summaries endpoint
+
+- Added `/experiments/summary` route in `prompt-experiments` for aggregate success rates.
+- Proxied summaries through the orchestrator and updated portal listings.
+- Documented usage and extended service tests.


### PR DESCRIPTION
## Summary
- expose `/experiments/summary` to deliver aggregated success rates
- proxy summaries through orchestrator and show best variant in portal
- document usage and extend prompt experiment tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689668a8eaf883319f34c4be631b9542