### PR TITLE
Allow editing prompt experiment variants

### DIFF
--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -601,6 +601,23 @@ app.post('/api/experiments/:id/variants', async (req, res) => {
   }
 });
 
+app.put('/api/experiments/:id/variants/:name', async (req, res) => {
+  try {
+    const response = await fetch(
+      `${PROMPT_EXP_URL}/experiments/${encodeURIComponent(req.params.id)}/variants/${encodeURIComponent(req.params.name)}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req.body),
+      }
+    );
+    const json = await response.json();
+    res.status(response.status).json(json);
+  } catch {
+    res.status(500).json({ error: 'service unavailable' });
+  }
+});
+
 app.delete('/api/experiments/:id/variants/:name', async (req, res) => {
   try {
     const response = await fetch(

--- a/apps/portal/src/pages/prompt-tests.tsx
+++ b/apps/portal/src/pages/prompt-tests.tsx
@@ -132,6 +132,20 @@ function VariantList({
   variants: Record<string, any>;
   mutate: () => void;
 }) {
+  const updatePrompt = async (name: string, current: string) => {
+    const promptText = window.prompt('New prompt', current);
+    if (!promptText) return;
+    await fetch(
+      `/api/experiments/${id}/variants/${encodeURIComponent(name)}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: promptText }),
+      }
+    );
+    mutate();
+  };
+
   const remove = async (name: string) => {
     await fetch(
       `/api/experiments/${id}/variants/${encodeURIComponent(name)}`,
@@ -145,6 +159,12 @@ function VariantList({
       {Object.entries(variants).map(([name, v]) => (
         <li key={name}>
           <strong>{name}:</strong> {v.prompt} (success {v.success}/{v.total})
+          <button
+            onClick={() => updatePrompt(name, v.prompt)}
+            style={{ marginLeft: 4 }}
+          >
+            Edit
+          </button>
           <button onClick={() => remove(name)} style={{ marginLeft: 4 }}>
             Delete
           </button>

--- a/docs/prompt-ab-testing.md
+++ b/docs/prompt-ab-testing.md
@@ -7,6 +7,7 @@ The prompt experiments service allows comparing multiple prompt variants and col
 1. Start the service with `pnpm --filter prompt-experiments build && node services/prompt-experiments/dist/index.js`.
 2. Use the orchestrator endpoints `/api/experiments` to create experiments and `/api/experiments/:id/variants` to add variants. When recording results or setting a winner via `PUT /api/experiments/:id`, provide variant and winner names that exist on the experiment; otherwise a `400` error is returned.
 3. Retrieve aggregated success rates with `/api/experiments/summary`.
-4. Remove a variant with `DELETE /api/experiments/:id/variants/:name`.
-5. Visit `/prompt-tests` in the portal to launch tests, add variants and monitor results.
-6. Download CSV results from `/api/experiments/:id/export` for further analysis.
+4. Update a variant's prompt via `PUT /api/experiments/:id/variants/:name`.
+5. Remove a variant with `DELETE /api/experiments/:id/variants/:name`.
+6. Visit `/prompt-tests` in the portal to launch tests, add variants and monitor results.
+7. Download CSV results from `/api/experiments/:id/export` for further analysis.

--- a/services/prompt-experiments/README.md
+++ b/services/prompt-experiments/README.md
@@ -8,6 +8,7 @@ This service manages prompt A/B tests and metrics.
 - `GET /experiments/summary` – list summaries with success rates
 - `POST /experiments` – create a new experiment
 - `POST /experiments/:id/variants` – add a variant
+- `PUT /experiments/:id/variants/:name` – update a variant's prompt
 - `DELETE /experiments/:id/variants/:name` – remove a variant (clears winner if deleted)
 - `GET /experiments/:id` – fetch a single experiment
 - `GET /experiments/:id/summary` – get success rates and best variant

--- a/services/prompt-experiments/src/index.test.ts
+++ b/services/prompt-experiments/src/index.test.ts
@@ -127,3 +127,19 @@ test('deletes variant and clears winner', async () => {
   expect(fetchExp.body.variants.B).toBeUndefined();
   expect(fetchExp.body.winner).toBeUndefined();
 });
+
+test('updates variant prompt with sanitization', async () => {
+  const create = await request(app)
+    .post('/experiments')
+    .send({ name: 'upd', variants: { A: { prompt: 'a' } } });
+  const id = create.body.id;
+
+  const update = await request(app)
+    .put(`/experiments/${id}/variants/A`)
+    .send({ prompt: '<b>c</b>' });
+  expect(update.status).toBe(200);
+  expect(update.body.prompt).toBe('&lt;b&gt;c&lt;&#x2F;b&gt;');
+
+  const fetchExp = await request(app).get(`/experiments/${id}`);
+  expect(fetchExp.body.variants.A.prompt).toBe('&lt;b&gt;c&lt;&#x2F;b&gt;');
+});

--- a/services/prompt-experiments/src/index.ts
+++ b/services/prompt-experiments/src/index.ts
@@ -141,6 +141,23 @@ app.post('/experiments/:id/variants', (req, res) => {
   res.status(201).json(exp.variants[cleanName]);
 });
 
+app.put('/experiments/:id/variants/:name', (req, res) => {
+  const { prompt } = req.body as { prompt?: string };
+  if (!prompt) return res.status(400).json({ error: 'missing fields' });
+
+  const list = read();
+  const exp = find(req.params.id, list);
+  if (!exp) return res.status(404).json({ error: 'not found' });
+
+  const variantName = sanitize(req.params.name);
+  const variant = exp.variants[variantName];
+  if (!variant) return res.status(404).json({ error: 'variant not found' });
+
+  variant.prompt = sanitize(prompt);
+  save(list);
+  res.json(variant);
+});
+
 app.delete('/experiments/:id/variants/:name', (req, res) => {
   const list = read();
   const exp = find(req.params.id, list);

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -610,3 +610,9 @@ This file records brief summaries of each pull request.
 - Added DELETE endpoint to remove variants and clear winners in `services/prompt-experiments` with tests.
 - Proxied deletion through the orchestrator and updated portal UI to remove variants.
 - Documented the new route in service README and prompt A/B testing guide.
+
+## PR <pending> - Variant prompt editing
+
+- Added `PUT /experiments/:id/variants/:name` endpoint to update variant prompts with sanitization.
+- Proxied the route through the orchestrator and enabled editing in the portal UI.
+- Updated README and docs, and extended service tests for the new behavior.


### PR DESCRIPTION
## Summary
- enable updating variant prompts via PUT /experiments/:id/variants/:name
- proxy variant prompt updates through orchestrator and portal UI
- document editing workflow in README and prompt A/B testing guide

## Testing
- `npx jest services/prompt-experiments/src/index.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68992256ce448331aca9b154b660a44c