### PR TITLE
feat: add experiment reset

### DIFF
--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -660,6 +660,19 @@ app.get('/api/experiments/:id/export', async (req, res) => {
   }
 });
 
+app.post('/api/experiments/:id/reset', async (req, res) => {
+  try {
+    const response = await fetch(
+      `${PROMPT_EXP_URL}/experiments/${encodeURIComponent(req.params.id)}/reset`,
+      { method: 'POST' }
+    );
+    const json = await response.json();
+    res.status(response.status).json(json);
+  } catch {
+    res.status(500).json({ error: 'service unavailable' });
+  }
+});
+
 app.put('/api/experiments/:id', async (req, res) => {
   try {
     const response = await fetch(

--- a/apps/portal/src/pages/prompt-tests.tsx
+++ b/apps/portal/src/pages/prompt-tests.tsx
@@ -35,6 +35,11 @@ export default function PromptTests() {
     mutate();
   };
 
+  const reset = async (id: string) => {
+    await fetch(`/api/experiments/${id}/reset`, { method: 'POST' });
+    mutate();
+  };
+
   if (!data) return <p>Loading...</p>;
 
   return (
@@ -82,6 +87,9 @@ export default function PromptTests() {
           />
           <VariantAdder id={exp.id} mutate={mutate} />
           <a href={`/api/experiments/${exp.id}/export`}>Export CSV</a>
+          <button onClick={() => reset(exp.id)} style={{ marginLeft: 4 }}>
+            Reset
+          </button>
         </div>
       ))}
     </div>

--- a/services/prompt-experiments/README.md
+++ b/services/prompt-experiments/README.md
@@ -13,6 +13,7 @@ This service manages prompt A/B tests and metrics.
 - `GET /experiments/:id` – fetch a single experiment
 - `GET /experiments/:id/summary` – get success rates and best variant
 - `GET /experiments/:id/export` – download results as CSV
+- `POST /experiments/:id/reset` – reset all variant metrics and clear winner
 - `PUT /experiments/:id` – record results or set winner. Variant and winner names must match existing variants or the request will fail with HTTP 400.
 - `DELETE /experiments/:id` – remove an experiment
 

--- a/services/prompt-experiments/src/index.ts
+++ b/services/prompt-experiments/src/index.ts
@@ -194,6 +194,21 @@ app.get('/experiments/:id/export', (req, res) => {
   res.send(csv);
 });
 
+app.post('/experiments/:id/reset', (req, res) => {
+  const list = read();
+  const exp = find(req.params.id, list);
+  if (!exp) return res.status(404).json({ error: 'not found' });
+
+  for (const variant of Object.values(exp.variants)) {
+    variant.success = 0;
+    variant.total = 0;
+  }
+  delete exp.winner;
+
+  save(list);
+  res.json(exp);
+});
+
 app.put('/experiments/:id', (req, res) => {
   const { variant, success, winner } = req.body as {
     variant?: string;

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -616,3 +616,9 @@ This file records brief summaries of each pull request.
 - Added `PUT /experiments/:id/variants/:name` endpoint to update variant prompts with sanitization.
 - Proxied the route through the orchestrator and enabled editing in the portal UI.
 - Updated README and docs, and extended service tests for the new behavior.
+
+## PR <pending> - Experiment metrics reset
+
+- Added `POST /experiments/:id/reset` endpoint in `services/prompt-experiments` to clear variant stats and winner.
+- Proxied reset route through the orchestrator and exposed a Reset button on the portal page.
+- Documented the new endpoint and marked task 196 complete in the tracker.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -199,3 +199,4 @@
 | 193 | Cross-Chain Plugin License Sync | Completed |
 | 194 | Edge Auto-Scaling | Completed |
 | 195 | Prompt A/B Testing Platform | Completed |
+| 196 | Experiment Reset Endpoint | Completed |


### PR DESCRIPTION
## Summary
- allow prompt experiment metrics to be reset via POST `/experiments/:id/reset`
- proxy reset route through orchestrator and expose Reset button in portal
- document new endpoint and mark related task complete

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689bd0343504833192eb0910b7f8afa0