### PR TITLE
feat: allow renaming prompt experiments

### DIFF
--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -673,6 +673,23 @@ app.post('/api/experiments/:id/reset', async (req, res) => {
   }
 });
 
+app.put('/api/experiments/:id/name', async (req, res) => {
+  try {
+    const response = await fetch(
+      `${PROMPT_EXP_URL}/experiments/${encodeURIComponent(req.params.id)}/name`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req.body),
+      }
+    );
+    const json = await response.json();
+    res.status(response.status).json(json);
+  } catch {
+    res.status(500).json({ error: 'service unavailable' });
+  }
+});
+
 app.put('/api/experiments/:id', async (req, res) => {
   try {
     const response = await fetch(

--- a/apps/portal/src/pages/prompt-tests.tsx
+++ b/apps/portal/src/pages/prompt-tests.tsx
@@ -40,6 +40,17 @@ export default function PromptTests() {
     mutate();
   };
 
+  const rename = async (id: string, current: string) => {
+    const newName = window.prompt('New name', current);
+    if (!newName) return;
+    await fetch(`/api/experiments/${id}/name`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newName }),
+    });
+    mutate();
+  };
+
   if (!data) return <p>Loading...</p>;
 
   return (
@@ -71,6 +82,12 @@ export default function PromptTests() {
         <div key={exp.id} style={{ marginBottom: 10 }}>
           <strong>{exp.name}</strong>{' '}
           {exp.winner && <span>(winner: {exp.winner})</span>}
+          <button
+            onClick={() => rename(exp.id, exp.name)}
+            style={{ marginLeft: 4 }}
+          >
+            Rename
+          </button>
           <div>
             <button onClick={() => record(exp.id, 'A', true)}>A Success</button>
             <button

--- a/docs/prompt-ab-testing.md
+++ b/docs/prompt-ab-testing.md
@@ -11,3 +11,4 @@ The prompt experiments service allows comparing multiple prompt variants and col
 5. Remove a variant with `DELETE /api/experiments/:id/variants/:name`.
 6. Visit `/prompt-tests` in the portal to launch tests, add variants and monitor results.
 7. Download CSV results from `/api/experiments/:id/export` for further analysis.
+8. Rename experiments using `PUT /api/experiments/:id/name`.

--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -2430,3 +2430,21 @@ This file expands on each item in `Tasks.md` with a short description of the exp
     3. Implement `portal/prompt-tests.tsx` to launch and monitor tests.
     4. Document workflows in `docs/prompt-ab-testing.md`.
 
+196. **Experiment Reset Endpoint**
+
+   - Clear experiment metrics and winner.
+   - Task details: Add a `/experiments/:id/reset` endpoint and integrate across services.
+  - Steps:
+    1. Implement reset route in `services/prompt-experiments`.
+    2. Proxy through the orchestrator and add portal Reset button.
+    3. Document the endpoint and tests.
+
+197. **Experiment Rename Endpoint**
+
+   - Allow renaming experiments.
+   - Task details: Add a `/experiments/:id/name` endpoint and update clients.
+  - Steps:
+    1. Add rename route in `services/prompt-experiments` with sanitization.
+    2. Proxy via the orchestrator and expose rename UI in the portal.
+    3. Update docs and tests.
+

--- a/services/prompt-experiments/README.md
+++ b/services/prompt-experiments/README.md
@@ -14,6 +14,7 @@ This service manages prompt A/B tests and metrics.
 - `GET /experiments/:id/summary` – get success rates and best variant
 - `GET /experiments/:id/export` – download results as CSV
 - `POST /experiments/:id/reset` – reset all variant metrics and clear winner
+- `PUT /experiments/:id/name` – rename an experiment
 - `PUT /experiments/:id` – record results or set winner. Variant and winner names must match existing variants or the request will fail with HTTP 400.
 - `DELETE /experiments/:id` – remove an experiment
 

--- a/services/prompt-experiments/src/index.test.ts
+++ b/services/prompt-experiments/src/index.test.ts
@@ -163,3 +163,19 @@ test('resets experiment metrics and clears winner', async () => {
   expect(reset.body.variants.A.success).toBe(0);
   expect(reset.body.variants.A.total).toBe(0);
 });
+
+test('renames experiment with sanitization', async () => {
+  const create = await request(app)
+    .post('/experiments')
+    .send({ name: 'old', variants: { A: { prompt: 'a' } } });
+  const id = create.body.id;
+
+  const rename = await request(app)
+    .put(`/experiments/${id}/name`)
+    .send({ name: '<b>new</b>' });
+  expect(rename.status).toBe(200);
+  expect(rename.body.name).toBe('&lt;b&gt;new&lt;&#x2F;b&gt;');
+
+  const fetchExp = await request(app).get(`/experiments/${id}`);
+  expect(fetchExp.body.name).toBe('&lt;b&gt;new&lt;&#x2F;b&gt;');
+});

--- a/services/prompt-experiments/src/index.ts
+++ b/services/prompt-experiments/src/index.ts
@@ -209,6 +209,19 @@ app.post('/experiments/:id/reset', (req, res) => {
   res.json(exp);
 });
 
+app.put('/experiments/:id/name', (req, res) => {
+  const { name } = req.body as { name?: string };
+  if (!name) return res.status(400).json({ error: 'missing fields' });
+
+  const list = read();
+  const exp = find(req.params.id, list);
+  if (!exp) return res.status(404).json({ error: 'not found' });
+
+  exp.name = sanitize(name);
+  save(list);
+  res.json(exp);
+});
+
 app.put('/experiments/:id', (req, res) => {
   const { variant, success, winner } = req.body as {
     variant?: string;

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -622,3 +622,9 @@ This file records brief summaries of each pull request.
 - Added `POST /experiments/:id/reset` endpoint in `services/prompt-experiments` to clear variant stats and winner.
 - Proxied reset route through the orchestrator and exposed a Reset button on the portal page.
 - Documented the new endpoint and marked task 196 complete in the tracker.
+
+## PR <pending> - Experiment rename endpoint
+
+- Added `PUT /experiments/:id/name` in `services/prompt-experiments` to rename experiments with sanitization.
+- Proxied rename route through the orchestrator and added a Rename button in the portal UI.
+- Updated documentation and marked task 197 complete in the tracker.

--- a/tasks_status.md
+++ b/tasks_status.md
@@ -200,3 +200,4 @@
 | 194 | Edge Auto-Scaling | Completed |
 | 195 | Prompt A/B Testing Platform | Completed |
 | 196 | Experiment Reset Endpoint | Completed |
+| 197 | Experiment Rename Endpoint | Completed |


### PR DESCRIPTION
## Summary
- add `PUT /experiments/:id/name` to rename prompt experiments with sanitization
- proxy rename route through orchestrator and expose Rename button in portal UI
- document rename workflow and record task completion

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689fc014c6488331a638a9dfa7b9b9fa