### PR TITLE
Proxy variant reset endpoint for prompt experiments

### DIFF
--- a/apps/orchestrator/src/index.test.ts
+++ b/apps/orchestrator/src/index.test.ts
@@ -458,3 +458,10 @@ test('edge scaling triggers update', async () => {
   expect(res.status).toBe(201);
   expect(updateEdgeScaling).toHaveBeenCalled();
 });
+
+test('variant reset proxies to experiment service', async () => {
+  const res = await request(app)
+    .post('/api/experiments/e1/variants/A/reset')
+    .set('x-tenant-id', 't1');
+  expect(res.status).toBe(200);
+});

--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -637,7 +637,25 @@ app.put(
     } catch {
       res.status(500).json({ error: 'service unavailable' });
     }
-  } 
+  }
+);
+
+app.post(
+  '/api/experiments/:id/variants/:name/reset',
+  async (req, res) => {
+    try {
+      const response = await fetch(
+        `${PROMPT_EXP_URL}/experiments/${encodeURIComponent(
+          req.params.id
+        )}/variants/${encodeURIComponent(req.params.name)}/reset`,
+        { method: 'POST' }
+      );
+      const json = await response.json();
+      res.status(response.status).json(json);
+    } catch {
+      res.status(500).json({ error: 'service unavailable' });
+    }
+  }
 );
 
 app.post(

--- a/apps/portal/src/pages/prompt-tests.tsx
+++ b/apps/portal/src/pages/prompt-tests.tsx
@@ -199,6 +199,14 @@ function VariantList({
     mutate();
   };
 
+  const resetVariant = async (name: string) => {
+    await fetch(
+      `/api/experiments/${id}/variants/${encodeURIComponent(name)}/reset`,
+      { method: 'POST' }
+    );
+    mutate();
+  };
+
   const remove = async (name: string) => {
     await fetch(
       `/api/experiments/${id}/variants/${encodeURIComponent(name)}`,
@@ -223,6 +231,9 @@ function VariantList({
           </button>
           <button onClick={() => cloneVariant(name)} style={{ marginLeft: 4 }}>
             Clone
+          </button>
+          <button onClick={() => resetVariant(name)} style={{ marginLeft: 4 }}>
+            Reset
           </button>
           <button onClick={() => remove(name)} style={{ marginLeft: 4 }}>
             Delete

--- a/docs/prompt-ab-testing.md
+++ b/docs/prompt-ab-testing.md
@@ -14,3 +14,5 @@ The prompt experiments service allows comparing multiple prompt variants and col
 8. Download CSV results from `/api/experiments/:id/export` for further analysis.
 9. Rename experiments using `PUT /api/experiments/:id/name`.
 10. Duplicate an experiment with `POST /api/experiments/:id/clone` to start fresh tests.
+11. Reset experiment metrics with `POST /api/experiments/:id/reset` or clear a single
+    variant's counters via `POST /api/experiments/:id/variants/:name/reset`.

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -651,3 +651,8 @@ This file records brief summaries of each pull request.
 - Added `POST /experiments/:id/variants/:name/clone` in `prompt-experiments` for duplicating variants with fresh metrics.
 - Proxied the endpoint through the orchestrator and exposed a Clone control in the portal UI.
 - Documented the workflow and marked task 201 complete.
+
+## PR <pending> - Variant reset orchestration
+
+- Proxied `POST /experiments/:id/variants/:name/reset` through the orchestrator.
+- Added portal controls to reset variant metrics and documented reset endpoints.


### PR DESCRIPTION
## Summary
- Proxy `/experiments/:id/variants/:name/reset` through orchestrator
- Add portal controls for resetting individual variant metrics
- Document experiment and variant reset workflow

## Testing
- `pnpm test --filter orchestrator` *(skipped)*
- `pnpm test --filter prompt-experiments` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf71cf9308331bb086182d3bfd0b0